### PR TITLE
Add check if indexpath contains exactly two indices

### DIFF
--- a/SectionKit.xcodeproj/project.pbxproj
+++ b/SectionKit.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 /* Begin PBXBuildFile section */
 		5A7C9FD02509250900A32BE6 /* DifferenceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A7C9FCF2509250900A32BE6 /* DifferenceKit.framework */; };
 		5A7C9FD6250A2ECC00A32BE6 /* DiffingListCollectionViewAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C9FD5250A2ECC00A32BE6 /* DiffingListCollectionViewAdapterTests.swift */; };
+		5AD17C77252B6DF5009DEF3F /* IndexPath+IsValid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD17C76252B6DF5009DEF3F /* IndexPath+IsValid.swift */; };
 		5AED5914250A34B600E97796 /* DifferenceKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A7C9FCF2509250900A32BE6 /* DifferenceKit.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5AFC546C250BBB250099E3BD /* CollectionViewContext+CollectionViewSectionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC546B250BBB250099E3BD /* CollectionViewContext+CollectionViewSectionUpdate.swift */; };
 		5AFC546E250BBF3A0099E3BD /* CollectionViewContext+CollectionViewUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC546D250BBF3A0099E3BD /* CollectionViewContext+CollectionViewUpdate.swift */; };
@@ -142,6 +143,7 @@
 /* Begin PBXFileReference section */
 		5A7C9FCF2509250900A32BE6 /* DifferenceKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DifferenceKit.framework; path = Carthage/Build/iOS/DifferenceKit.framework; sourceTree = "<group>"; };
 		5A7C9FD5250A2ECC00A32BE6 /* DiffingListCollectionViewAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffingListCollectionViewAdapterTests.swift; sourceTree = "<group>"; };
+		5AD17C76252B6DF5009DEF3F /* IndexPath+IsValid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexPath+IsValid.swift"; sourceTree = "<group>"; };
 		5AFC546B250BBB250099E3BD /* CollectionViewContext+CollectionViewSectionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionViewContext+CollectionViewSectionUpdate.swift"; sourceTree = "<group>"; };
 		5AFC546D250BBF3A0099E3BD /* CollectionViewContext+CollectionViewUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionViewContext+CollectionViewUpdate.swift"; sourceTree = "<group>"; };
 		OBJ_10 /* DiffingListSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffingListSectionController.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				OBJ_59 /* CollectionDifference+Changes.swift */,
 				OBJ_60 /* Move.swift */,
 				OBJ_61 /* UICollectionView+Apply.swift */,
+				5AD17C76252B6DF5009DEF3F /* IndexPath+IsValid.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -684,6 +687,7 @@
 				OBJ_187 /* SectionDragDelegate.swift in Sources */,
 				OBJ_188 /* SectionDropDelegate.swift in Sources */,
 				5AFC546C250BBB250099E3BD /* CollectionViewContext+CollectionViewSectionUpdate.swift in Sources */,
+				5AD17C77252B6DF5009DEF3F /* IndexPath+IsValid.swift in Sources */,
 				OBJ_189 /* SectionFlowDelegate.swift in Sources */,
 				OBJ_190 /* SectionIndexPath.swift in Sources */,
 				OBJ_191 /* CollectionViewSectionBatchOperation.swift in Sources */,

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDataSource.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDataSource.swift
@@ -16,7 +16,7 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
 
     open func collectionView(_ collectionView: UICollectionView,
                              cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else {
+        guard indexPath.isSectionIndexValid(for: sections) else {
             assertionFailure("Could not find the specified section")
             return UICollectionViewCell()
         }
@@ -28,7 +28,7 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
     open func collectionView(_ collectionView: UICollectionView,
                              viewForSupplementaryElementOfKind elementKind: String,
                              at indexPath: IndexPath) -> UICollectionReusableView {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else {
+        guard indexPath.isSectionIndexValid(for: sections) else {
             assertionFailure("Could not find the specified section")
             return UICollectionReusableView()
         }
@@ -52,7 +52,7 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
 
     open func collectionView(_ collectionView: UICollectionView,
                              canMoveItemAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else {
+        guard indexPath.isSectionIndexValid(for: sections) else {
             assertionFailure("Could not find the specified section")
             return false
         }
@@ -64,11 +64,13 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
     open func collectionView(_ collectionView: UICollectionView,
                              moveItemAt sourceIndexPath: IndexPath,
                              to destinationIndexPath: IndexPath) {
-        guard sourceIndexPath.section >= 0 && sourceIndexPath.section < sections.count else {
+        guard sourceIndexPath.isSectionIndexValid(for: sections) else {
             assertionFailure("Could not find the specified section")
             return
         }
-        guard allowReorderingBetweenDifferentSections || sourceIndexPath.section == destinationIndexPath.section else {
+        let moveInsideSection = destinationIndexPath.isSectionIndexValid(for: sections)
+            && sourceIndexPath.section == destinationIndexPath.section
+        guard moveInsideSection || allowReorderingBetweenDifferentSections else {
             return
         }
         let sourceSectionIndexPath = SectionIndexPath(externalRepresentation: sourceIndexPath,

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDelegate.swift
@@ -5,7 +5,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              shouldHighlightItemAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return true }
+        guard indexPath.isSectionIndexValid(for: sections) else { return true }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldHighlightItem(at: sectionIndexPath) ?? true
@@ -13,7 +13,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              didHighlightItemAt indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.didHighlightItem(at: sectionIndexPath)
@@ -21,7 +21,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              didUnhighlightItemAt indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.didUnhighlightItem(at: sectionIndexPath)
@@ -31,7 +31,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return true }
+        guard indexPath.isSectionIndexValid(for: sections) else { return true }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldSelectItem(at: sectionIndexPath) ?? true
@@ -39,7 +39,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              shouldDeselectItemAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return true }
+        guard indexPath.isSectionIndexValid(for: sections) else { return true }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldDeselectItem(at: sectionIndexPath) ?? true
@@ -47,7 +47,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              didSelectItemAt indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.didSelectItem(at: sectionIndexPath)
@@ -55,7 +55,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              didDeselectItemAt indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.didDeselectItem(at: sectionIndexPath)
@@ -66,7 +66,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              willDisplay cell: UICollectionViewCell,
                              forItemAt indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.willDisplay(cell: cell, at: sectionIndexPath)
@@ -76,7 +76,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              willDisplaySupplementaryView view: UICollectionReusableView,
                              forElementKind elementKind: String,
                              at indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         let delegate = sections[indexPath.section].controller.delegate
@@ -93,7 +93,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              didEndDisplaying cell: UICollectionViewCell,
                              forItemAt indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.didEndDisplaying(cell: cell, at: sectionIndexPath)
@@ -103,7 +103,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              didEndDisplayingSupplementaryView view: UICollectionReusableView,
                              forElementOfKind elementKind: String,
                              at indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         let delegate = sections[indexPath.section].controller.delegate
@@ -122,7 +122,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     @available(iOS, introduced: 6.0, deprecated: 13.0)
     open func collectionView(_ collectionView: UICollectionView,
                              shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return false }
+        guard indexPath.isSectionIndexValid(for: sections) else { return false }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldShowMenuForItem(at: sectionIndexPath) ?? false
@@ -133,7 +133,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              canPerformAction action: Selector,
                              forItemAt indexPath: IndexPath,
                              withSender sender: Any?) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return false }
+        guard indexPath.isSectionIndexValid(for: sections) else { return false }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?.canPerform(action: action,
@@ -146,7 +146,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              performAction action: Selector,
                              forItemAt indexPath: IndexPath,
                              withSender sender: Any?) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.perform(action: action,
@@ -167,7 +167,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              canFocusItemAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else {
+        guard indexPath.isSectionIndexValid(for: sections) else {
             return self.collectionView(collectionView, shouldSelectItemAt: indexPath)
         }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
@@ -207,7 +207,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              shouldSpringLoadItemAt indexPath: IndexPath,
                              with context: UISpringLoadedInteractionContext) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return true }
+        guard indexPath.isSectionIndexValid(for: sections) else { return true }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldSpringLoadItem(at: sectionIndexPath,
@@ -219,7 +219,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     @available(iOS 13.0, *)
     open func collectionView(_ collectionView: UICollectionView,
                              shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return false }
+        guard indexPath.isSectionIndexValid(for: sections) else { return false }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?
@@ -229,7 +229,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     @available(iOS 13.0, *)
     open func collectionView(_ collectionView: UICollectionView,
                              didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return }
+        guard indexPath.isSectionIndexValid(for: sections) else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         sections[indexPath.section].controller.delegate?.didBeginMultipleSelectionInteraction(at: sectionIndexPath)
@@ -243,7 +243,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              contextMenuConfigurationForItemAt indexPath: IndexPath,
                              point: CGPoint) -> UIContextMenuConfiguration? {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return nil }
+        guard indexPath.isSectionIndexValid(for: sections) else { return nil }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.delegate?.contextMenuConfigurationForItem(at: sectionIndexPath,

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDragDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDragDelegate.swift
@@ -6,7 +6,7 @@ extension ListCollectionViewAdapter: UICollectionViewDragDelegate {
                              itemsForBeginning session: UIDragSession,
                              at indexPath: IndexPath) -> [UIDragItem] {
         guard
-            indexPath.section >= 0 && indexPath.section < sections.count,
+            indexPath.isSectionIndexValid(for: sections),
             let dragDelegate = sections[indexPath.section].controller.dragDelegate
             else { return [] }
         session.localContext = sections[indexPath.section].controller
@@ -20,7 +20,7 @@ extension ListCollectionViewAdapter: UICollectionViewDragDelegate {
                              at indexPath: IndexPath,
                              point: CGPoint) -> [UIDragItem] {
         guard
-            indexPath.section >= 0 && indexPath.section < sections.count,
+            indexPath.isSectionIndexValid(for: sections),
             session.localContext as? SectionController === sections[indexPath.section].controller,
             let dragDelegate = sections[indexPath.section].controller.dragDelegate
             else { return [] }
@@ -32,7 +32,7 @@ extension ListCollectionViewAdapter: UICollectionViewDragDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
         guard
-            indexPath.section >= 0 && indexPath.section < sections.count,
+            indexPath.isSectionIndexValid(for: sections),
             let dragDelegate = sections[indexPath.section].controller.dragDelegate
             else { return nil }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDropDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDropDelegate.swift
@@ -14,7 +14,7 @@ extension ListCollectionViewAdapter: UICollectionViewDropDelegate {
     ) -> UICollectionViewDropProposal {
         guard
             let indexPath = destinationIndexPath,
-            indexPath.section >= 0 && indexPath.section < sections.count
+            indexPath.isSectionIndexValid(for: sections)
             else { return UICollectionViewDropProposal(operation: .forbidden) }
         if !allowReorderingBetweenDifferentSections {
             guard
@@ -32,7 +32,7 @@ extension ListCollectionViewAdapter: UICollectionViewDropDelegate {
                              performDropWith coordinator: UICollectionViewDropCoordinator) {
         guard
             let indexPath = coordinator.destinationIndexPath,
-            indexPath.section >= 0 && indexPath.section < sections.count
+            indexPath.isSectionIndexValid(for: sections)
             else { return }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
@@ -54,7 +54,7 @@ extension ListCollectionViewAdapter: UICollectionViewDropDelegate {
 
     open func collectionView(_ collectionView: UICollectionView,
                              dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
-        guard indexPath.section >= 0 && indexPath.section < sections.count else { return nil }
+        guard indexPath.isSectionIndexValid(for: sections) else { return nil }
         let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
                                                 internalRepresentation: indexPath.item)
         return sections[indexPath.section].controller.dropDelegate?.dropPreviewParametersForItem(at: sectionIndexPath)

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewFlowLayout.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewFlowLayout.swift
@@ -5,7 +5,7 @@ extension ListCollectionViewAdapter: UICollectionViewDelegateFlowLayout {
                              layout collectionViewLayout: UICollectionViewLayout,
                              sizeForItemAt indexPath: IndexPath) -> CGSize {
         guard
-            indexPath.section >= 0 && indexPath.section < sections.count,
+            indexPath.isSectionIndexValid(for: sections),
             let flowDelegate = sections[indexPath.section].controller.flowDelegate
             else {
                 return (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize ?? CGSize(width: 50, height: 50)

--- a/SectionKit/Sources/Utility/IndexPath+IsValid.swift
+++ b/SectionKit/Sources/Utility/IndexPath+IsValid.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension IndexPath {
+    internal func isSectionIndexValid(for sections: [Any]) -> Bool {
+        count == 2 // precondition of the `section` property
+            && section >= 0
+            && section < sections.count
+
+    }
+
+    internal func isItemIndexValid(for items: [Any]) -> Bool {
+        count == 2 // precondition of the `item` property
+            && item >= 0
+            && item < items.count
+    }
+}


### PR DESCRIPTION
This PR adds a check if the given `IndexPath` contains exactly two indices as indicated by the precondition of the `section` property:
> /// The section of this index path, when used with `UITableView`.
///
/// - precondition: The index path must have exactly two elements.