### PR TITLE
Rename externalRepresentation and internalRepresentation to more descriptive names

### DIFF
--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDataSource.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDataSource.swift
@@ -20,8 +20,8 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
             assertionFailure("Could not find the specified section")
             return UICollectionViewCell()
         }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.dataSource.cellForItem(at: sectionIndexPath)
     }
 
@@ -32,8 +32,8 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
             assertionFailure("Could not find the specified section")
             return UICollectionReusableView()
         }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
 
         let sectionController = sections[indexPath.section]
 
@@ -56,8 +56,8 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
             assertionFailure("Could not find the specified section")
             return false
         }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.dataSource.canMoveItem(at: sectionIndexPath)
     }
 
@@ -73,10 +73,10 @@ extension ListCollectionViewAdapter: UICollectionViewDataSource {
         guard moveInsideSection || allowReorderingBetweenDifferentSections else {
             return
         }
-        let sourceSectionIndexPath = SectionIndexPath(externalRepresentation: sourceIndexPath,
-                                                      internalRepresentation: sourceIndexPath.item)
-        let destinationSectionIndexPath = SectionIndexPath(externalRepresentation: destinationIndexPath,
-                                                           internalRepresentation: destinationIndexPath.item)
+        let sourceSectionIndexPath = SectionIndexPath(indexInCollectionView: sourceIndexPath,
+                                                      indexInSectionController: sourceIndexPath.item)
+        let destinationSectionIndexPath = SectionIndexPath(indexInCollectionView: destinationIndexPath,
+                                                           indexInSectionController: destinationIndexPath.item)
         sections[sourceIndexPath.section].controller.dataSource.moveItem(at: sourceSectionIndexPath,
                                                                          to: destinationSectionIndexPath)
     }

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDelegate.swift
@@ -6,24 +6,24 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              shouldHighlightItemAt indexPath: IndexPath) -> Bool {
         guard indexPath.isSectionIndexValid(for: sections) else { return true }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldHighlightItem(at: sectionIndexPath) ?? true
     }
 
     open func collectionView(_ collectionView: UICollectionView,
                              didHighlightItemAt indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.didHighlightItem(at: sectionIndexPath)
     }
 
     open func collectionView(_ collectionView: UICollectionView,
                              didUnhighlightItemAt indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.didUnhighlightItem(at: sectionIndexPath)
     }
 
@@ -32,32 +32,32 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              shouldSelectItemAt indexPath: IndexPath) -> Bool {
         guard indexPath.isSectionIndexValid(for: sections) else { return true }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldSelectItem(at: sectionIndexPath) ?? true
     }
 
     open func collectionView(_ collectionView: UICollectionView,
                              shouldDeselectItemAt indexPath: IndexPath) -> Bool {
         guard indexPath.isSectionIndexValid(for: sections) else { return true }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldDeselectItem(at: sectionIndexPath) ?? true
     }
 
     open func collectionView(_ collectionView: UICollectionView,
                              didSelectItemAt indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.didSelectItem(at: sectionIndexPath)
     }
 
     open func collectionView(_ collectionView: UICollectionView,
                              didDeselectItemAt indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.didDeselectItem(at: sectionIndexPath)
     }
 
@@ -67,8 +67,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              willDisplay cell: UICollectionViewCell,
                              forItemAt indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.willDisplay(cell: cell, at: sectionIndexPath)
     }
 
@@ -77,8 +77,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              forElementKind elementKind: String,
                              at indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         let delegate = sections[indexPath.section].controller.delegate
         switch elementKind {
         case UICollectionView.elementKindSectionHeader:
@@ -94,8 +94,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              didEndDisplaying cell: UICollectionViewCell,
                              forItemAt indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.didEndDisplaying(cell: cell, at: sectionIndexPath)
     }
 
@@ -104,8 +104,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              forElementOfKind elementKind: String,
                              at indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         let delegate = sections[indexPath.section].controller.delegate
         switch elementKind {
         case UICollectionView.elementKindSectionHeader:
@@ -123,8 +123,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
         guard indexPath.isSectionIndexValid(for: sections) else { return false }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldShowMenuForItem(at: sectionIndexPath) ?? false
     }
 
@@ -134,8 +134,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              forItemAt indexPath: IndexPath,
                              withSender sender: Any?) -> Bool {
         guard indexPath.isSectionIndexValid(for: sections) else { return false }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.canPerform(action: action,
                                                                            forItemAt: sectionIndexPath,
                                                                            withSender: sender) ?? false
@@ -147,8 +147,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              forItemAt indexPath: IndexPath,
                              withSender sender: Any?) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.perform(action: action,
                                                                  forItemAt: sectionIndexPath,
                                                                  withSender: sender)
@@ -170,8 +170,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
         guard indexPath.isSectionIndexValid(for: sections) else {
             return self.collectionView(collectionView, shouldSelectItemAt: indexPath)
         }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.canFocusItem(at: sectionIndexPath)
             ?? self.collectionView(collectionView, shouldSelectItemAt: indexPath)
     }
@@ -208,8 +208,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              shouldSpringLoadItemAt indexPath: IndexPath,
                              with context: UISpringLoadedInteractionContext) -> Bool {
         guard indexPath.isSectionIndexValid(for: sections) else { return true }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.shouldSpringLoadItem(at: sectionIndexPath,
                                                                                      with: context) ?? true
     }
@@ -220,8 +220,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
         guard indexPath.isSectionIndexValid(for: sections) else { return false }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?
             .shouldBeginMultipleSelectionInteraction(at: sectionIndexPath) ?? false
     }
@@ -230,8 +230,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
         guard indexPath.isSectionIndexValid(for: sections) else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.delegate?.didBeginMultipleSelectionInteraction(at: sectionIndexPath)
     }
 
@@ -244,8 +244,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
                              contextMenuConfigurationForItemAt indexPath: IndexPath,
                              point: CGPoint) -> UIContextMenuConfiguration? {
         guard indexPath.isSectionIndexValid(for: sections) else { return nil }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.delegate?.contextMenuConfigurationForItem(at: sectionIndexPath,
                                                                                                 point: point)
     }

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDragDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDragDelegate.swift
@@ -10,8 +10,8 @@ extension ListCollectionViewAdapter: UICollectionViewDragDelegate {
             let dragDelegate = sections[indexPath.section].controller.dragDelegate
             else { return [] }
         session.localContext = sections[indexPath.section].controller
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return dragDelegate.dragItems(forBeginning: session, at: sectionIndexPath)
     }
 
@@ -24,8 +24,8 @@ extension ListCollectionViewAdapter: UICollectionViewDragDelegate {
             session.localContext as? SectionController === sections[indexPath.section].controller,
             let dragDelegate = sections[indexPath.section].controller.dragDelegate
             else { return [] }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return dragDelegate.dragItems(forAddingTo: session, at: sectionIndexPath, point: point)
     }
 
@@ -35,8 +35,8 @@ extension ListCollectionViewAdapter: UICollectionViewDragDelegate {
             indexPath.isSectionIndexValid(for: sections),
             let dragDelegate = sections[indexPath.section].controller.dragDelegate
             else { return nil }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return dragDelegate.dragPreviewParametersForItem(at: sectionIndexPath)
     }
 

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDropDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewDropDelegate.swift
@@ -21,8 +21,8 @@ extension ListCollectionViewAdapter: UICollectionViewDropDelegate {
                 session.localDragSession?.localContext as? SectionController === sections[indexPath.section].controller
                 else { return UICollectionViewDropProposal(operation: .forbidden) }
         }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.dropDelegate?.dropSessionDidUpdate(session,
                                                                                          at: sectionIndexPath)
             ?? UICollectionViewDropProposal(operation: .forbidden)
@@ -34,8 +34,8 @@ extension ListCollectionViewAdapter: UICollectionViewDropDelegate {
             let indexPath = coordinator.destinationIndexPath,
             indexPath.isSectionIndexValid(for: sections)
             else { return }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         sections[indexPath.section].controller.dropDelegate?.performDrop(at: sectionIndexPath,
                                                                          with: coordinator)
     }
@@ -55,8 +55,8 @@ extension ListCollectionViewAdapter: UICollectionViewDropDelegate {
     open func collectionView(_ collectionView: UICollectionView,
                              dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
         guard indexPath.isSectionIndexValid(for: sections) else { return nil }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return sections[indexPath.section].controller.dropDelegate?.dropPreviewParametersForItem(at: sectionIndexPath)
     }
 }

--- a/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewFlowLayout.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Generic/ListCollectionViewAdapter+UICollectionViewFlowLayout.swift
@@ -10,8 +10,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegateFlowLayout {
             else {
                 return (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize ?? CGSize(width: 50, height: 50)
         }
-        let sectionIndexPath = SectionIndexPath(externalRepresentation: indexPath,
-                                                internalRepresentation: indexPath.item)
+        let sectionIndexPath = SectionIndexPath(indexInCollectionView: indexPath,
+                                                indexInSectionController: indexPath.item)
         return flowDelegate.sizeForItem(at: sectionIndexPath, using: collectionViewLayout)
     }
 

--- a/SectionKit/Sources/Section/SectionIndexPath.swift
+++ b/SectionKit/Sources/Section/SectionIndexPath.swift
@@ -3,32 +3,32 @@ import Foundation
 /// A struct containing the internal and external index of an item.
 public struct SectionIndexPath {
     /// The index path of the item in the `UICollectionView`.
-    public let externalRepresentation: IndexPath
+    public let indexInCollectionView: IndexPath
 
-    /// The internal index of the item.
-    public let internalRepresentation: Int
+    /// The index of the item in the current `SectionController`.
+    public let indexInSectionController: Int
 
     /**
      Initialize an instance of `SectionIndexPath`.
 
-     - Parameter externalRepresentation: The index path of the item in the `UICollectionView`.
+     - Parameter indexInCollectionView: The index path of the item in the `UICollectionView`.
 
-     - Parameter internalRepresentation: The internal index of the item.
+     - Parameter indexInSectionController: The index of the item in the current `SectionController`.
      */
-    public init(externalRepresentation: IndexPath, internalRepresentation: Int) {
-        self.externalRepresentation = externalRepresentation
-        self.internalRepresentation = internalRepresentation
+    public init(indexInCollectionView: IndexPath, indexInSectionController: Int) {
+        self.indexInCollectionView = indexInCollectionView
+        self.indexInSectionController = indexInSectionController
     }
 
     /**
      Initialize an instance of `SectionIndexPath`.
 
-     - Parameter externalRepresentation: The index path of the item in the `UICollectionView`.
+     - Parameter indexInCollectionView: The index path of the item in the `UICollectionView`.
 
-     - Parameter internalRepresentation: The internal index of the item.
+     - Parameter indexInSectionController: The index of the item in the current `SectionController`.
      */
     public init(_ indexPath: IndexPath) {
-        self.externalRepresentation = indexPath
-        self.internalRepresentation = indexPath.item
+        self.indexInCollectionView = indexPath
+        self.indexInSectionController = indexPath.item
     }
 }

--- a/SectionKit/Tests/Section/SectionIndexPathTests.swift
+++ b/SectionKit/Tests/Section/SectionIndexPathTests.swift
@@ -3,16 +3,16 @@ import XCTest
 
 internal final class SectionIndexPathTests: XCTestCase {
     internal func testInitializeSectionIndexPath() {
-        let externalRepresentation = IndexPath(item: 0, section: 1)
-        let internalRepresentation = 0
+        let indexInCollectionView = IndexPath(item: 0, section: 1)
+        let indexInSectionController = 0
 
-        var input = SectionIndexPath(externalRepresentation: externalRepresentation,
-                                     internalRepresentation: internalRepresentation)
-        XCTAssertEqual(input.externalRepresentation, externalRepresentation)
-        XCTAssertEqual(input.internalRepresentation, internalRepresentation)
+        var input = SectionIndexPath(indexInCollectionView: indexInCollectionView,
+                                     indexInSectionController: indexInSectionController)
+        XCTAssertEqual(input.indexInCollectionView, indexInCollectionView)
+        XCTAssertEqual(input.indexInSectionController, indexInSectionController)
 
-        input = SectionIndexPath(externalRepresentation)
-        XCTAssertEqual(input.externalRepresentation, externalRepresentation)
-        XCTAssertEqual(input.internalRepresentation, internalRepresentation)
+        input = SectionIndexPath(indexInCollectionView)
+        XCTAssertEqual(input.indexInCollectionView, indexInCollectionView)
+        XCTAssertEqual(input.indexInSectionController, indexInSectionController)
     }
 }

--- a/introduction.md
+++ b/introduction.md
@@ -95,7 +95,7 @@ Go ahead and add the following code to the `StockSectionController`.
 override func headerView(at indexPath: SectionIndexPath) -> UICollectionReusableView {
     // 2
     guard let headerView = context?.dequeueReusableHeaderView(StockSectionHeaderView.self,
-                                                              for: indexPath.externalRepresentation) else {
+                                                              for: indexPath.indexInCollectionView) else {
             assertionFailure("Failed to dequeue cell from `context`")
             return UICollectionViewCell()
     }


### PR DESCRIPTION
This PR renames the following properties of `SectionIndexPath`:
- `externalRepresentation` -> `indexInCollectionView`
- `internalRepresentation` -> `indexInSectionController`