### PR TITLE
Add isModelEqual parameter to Section

### DIFF
--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
@@ -70,7 +70,9 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
                 if let existingSection = collectionViewSections.first(where: { $0.id == newSection.id }),
                    let existingController = existingSection.controller {
                     newSection.controller = existingController
-                    existingController.didUpdate(model: newSection.model)
+                    if !newSection.isModelEqual(newSection.model, existingSection.model) {
+                        existingController.didUpdate(model: newSection.model)
+                    }
                 }
             }
 

--- a/SectionKit/Sources/CollectionViewAdapter/SectionModel/Section.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/SectionModel/Section.swift
@@ -8,6 +8,9 @@ public class Section {
     /// The model of the section.
     public let model: Any
 
+    /// A closure to determine if two model instances are equal.
+    public let isModelEqual: (Any, Any) -> Bool
+
     private let controllerAccessor: () -> SectionController?
 
     /// A `SectionController` for this section.
@@ -20,13 +23,41 @@ public class Section {
 
      - Parameter model: The model of the section.
 
+     - Parameter isModelEqual: A closure to determine if two model instances are equal.
+
      - Parameter controller: A handler that produces the `SectionController` for this section.
      */
-    public init(id: AnyHashable,
-                model: Any,
-                controller: @autoclosure @escaping () -> SectionController?) {
+    public init<Model>(id: AnyHashable,
+                       model: Model,
+                       isModelEqual: @escaping (Model, Model) -> Bool,
+                       controller: @autoclosure @escaping () -> SectionController?) {
         self.id = id
         self.model = model
+        self.isModelEqual = { lhs, rhs in
+            guard let lhs = lhs as? Model, let rhs = rhs as? Model else { return false }
+            return isModelEqual(lhs, rhs)
+        }
+        self.controllerAccessor = controller
+    }
+
+    /**
+     Initialize an instance of `Section`.
+
+     - Parameter id: An identifier that uniquely identifies this section.
+
+     - Parameter model: The model of the section.
+
+     - Parameter controller: A handler that produces the `SectionController` for this section.
+     */
+    public init<Model: Equatable>(id: AnyHashable,
+                                  model: Model,
+                                  controller: @autoclosure @escaping () -> SectionController?) {
+        self.id = id
+        self.model = model
+        self.isModelEqual = { lhs, rhs in
+            guard let lhs = lhs as? Model, let rhs = rhs as? Model else { return false }
+            return lhs == rhs
+        }
         self.controllerAccessor = controller
     }
 }

--- a/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter.swift
@@ -72,7 +72,9 @@ open class SingleSectionCollectionViewAdapter: NSObject, CollectionViewAdapter {
                existingSection.id == newSection.id,
                let existingController = existingSection.controller {
                 newSection.controller = existingController
-                existingController.didUpdate(model: newSection.model)
+                if !newSection.isModelEqual(newSection.model, existingSection.model) {
+                    existingController.didUpdate(model: newSection.model)
+                }
             }
 
             guard let update = calculateUpdate(from: collectionViewSection,


### PR DESCRIPTION
This PR adds a `isModelEqual` closure as a parameter to the init of `Section`. This makes it possible to check two models for equality to check if a section should be reloaded.