### PR TITLE
Remove included section in SwiftLint config to fix build

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,3 @@
-included:
-    - Sources
-    - Tests
-
 whitelist_rules:
     - anyobject_protocol
     - array_init


### PR DESCRIPTION
Starting with SwiftLint version 0.41.0 the build kept failing because SwiftLint couldn't find any files.