### PR TITLE
Add init to both CollectionViewAdapter to provide initial sections

### DIFF
--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
@@ -22,8 +22,8 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
      */
     public init(viewController: UIViewController?,
                 collectionView: UICollectionView,
-                scrollViewDelegate: UIScrollViewDelegate? = nil,
-                dataSource: ListCollectionViewAdapterDataSource?) {
+                dataSource: ListCollectionViewAdapterDataSource?,
+                scrollViewDelegate: UIScrollViewDelegate? = nil) {
         let collectionContext = MainCollectionViewContext(viewController: viewController,
                                                           collectionView: collectionView)
         self.collectionContext = collectionContext
@@ -55,8 +55,8 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
      */
     public init(viewController: UIViewController?,
                 collectionView: UICollectionView,
-                scrollViewDelegate: UIScrollViewDelegate? = nil,
-                sections: [Section] = []) {
+                sections: [Section] = [],
+                scrollViewDelegate: UIScrollViewDelegate? = nil) {
         let collectionContext = MainCollectionViewContext(viewController: viewController,
                                                           collectionView: collectionView)
         self.collectionContext = collectionContext

--- a/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter.swift
@@ -22,8 +22,8 @@ open class SingleSectionCollectionViewAdapter: NSObject, CollectionViewAdapter {
      */
     public init(viewController: UIViewController?,
                 collectionView: UICollectionView,
-                scrollViewDelegate: UIScrollViewDelegate? = nil,
-                dataSource: SingleSectionCollectionViewAdapterDataSource?) {
+                dataSource: SingleSectionCollectionViewAdapterDataSource?,
+                scrollViewDelegate: UIScrollViewDelegate? = nil) {
         let collectionContext = MainCollectionViewContext(viewController: viewController,
                                                           collectionView: collectionView)
         self.collectionContext = collectionContext
@@ -55,8 +55,8 @@ open class SingleSectionCollectionViewAdapter: NSObject, CollectionViewAdapter {
      */
     public init(viewController: UIViewController?,
                 collectionView: UICollectionView,
-                scrollViewDelegate: UIScrollViewDelegate? = nil,
-                section: Section? = nil) {
+                section: Section? = nil,
+                scrollViewDelegate: UIScrollViewDelegate? = nil) {
         let collectionContext = MainCollectionViewContext(viewController: viewController,
                                                           collectionView: collectionView)
         self.collectionContext = collectionContext


### PR DESCRIPTION
This PR adds an init to `ListCollectionViewAdapter` that receives a list of `Section` and to `SingleSectionCollectionViewAdapter` that receives an optional `Section`. This enables creating an adapter that doesn't perform an initial round of diffing + updates to the `UICollectionView`.