### PR TITLE
Add sanity check if section ids are unique

### DIFF
--- a/SectionKit.xcodeproj/project.pbxproj
+++ b/SectionKit.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 /* Begin PBXBuildFile section */
 		5A7C9FD02509250900A32BE6 /* DifferenceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A7C9FCF2509250900A32BE6 /* DifferenceKit.framework */; };
 		5A7C9FD6250A2ECC00A32BE6 /* DiffingListCollectionViewAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C9FD5250A2ECC00A32BE6 /* DiffingListCollectionViewAdapterTests.swift */; };
-		5A86AB91257E3005009F798A /* Sequence+Unique.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A86AB90257E3005009F798A /* Sequence+Unique.swift */; };
+		5A86AB91257E3005009F798A /* Collection+IsUnique.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A86AB90257E3005009F798A /* Collection+IsUnique.swift */; };
 		5ABE045E2551C471007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABE045D2551C471007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDataSource.swift */; };
 		5ABE04652551C4A6007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDataSourcePrefetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABE04642551C4A6007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDataSourcePrefetching.swift */; };
 		5ABE046C2551C4CB007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABE046B2551C4CB007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDelegate.swift */; };
@@ -159,7 +159,7 @@
 /* Begin PBXFileReference section */
 		5A7C9FCF2509250900A32BE6 /* DifferenceKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DifferenceKit.framework; path = Carthage/Build/iOS/DifferenceKit.framework; sourceTree = "<group>"; };
 		5A7C9FD5250A2ECC00A32BE6 /* DiffingListCollectionViewAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffingListCollectionViewAdapterTests.swift; sourceTree = "<group>"; };
-		5A86AB90257E3005009F798A /* Sequence+Unique.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Unique.swift"; sourceTree = "<group>"; };
+		5A86AB90257E3005009F798A /* Collection+IsUnique.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+IsUnique.swift"; sourceTree = "<group>"; };
 		5ABE045D2551C471007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SingleSectionCollectionViewAdapter+UICollectionViewDataSource.swift"; sourceTree = "<group>"; };
 		5ABE04642551C4A6007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDataSourcePrefetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SingleSectionCollectionViewAdapter+UICollectionViewDataSourcePrefetching.swift"; sourceTree = "<group>"; };
 		5ABE046B2551C4CB007611D5 /* SingleSectionCollectionViewAdapter+UICollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SingleSectionCollectionViewAdapter+UICollectionViewDelegate.swift"; sourceTree = "<group>"; };
@@ -462,7 +462,7 @@
 				5AD17C76252B6DF5009DEF3F /* IndexPath+IsValid.swift */,
 				5AD17C89252C575D009DEF3F /* Sequence+Group.swift */,
 				5ABE04C82552A5A1007611D5 /* Optional+Extensions.swift */,
-				5A86AB90257E3005009F798A /* Sequence+Unique.swift */,
+				5A86AB90257E3005009F798A /* Collection+IsUnique.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -771,7 +771,7 @@
 				5AEC5D87254ADE2E0041B078 /* ListCollectionViewAdapter+Convenience.swift in Sources */,
 				OBJ_184 /* SectionController.swift in Sources */,
 				OBJ_185 /* SectionDataSource.swift in Sources */,
-				5A86AB91257E3005009F798A /* Sequence+Unique.swift in Sources */,
+				5A86AB91257E3005009F798A /* Collection+IsUnique.swift in Sources */,
 				OBJ_186 /* SectionDelegate.swift in Sources */,
 				5AD17C91252C5780009DEF3F /* ListCollectionViewAdapter+UICollectionViewDataSourcePrefetching.swift in Sources */,
 				5ABE048F2551C542007611D5 /* SingleSectionCollectionViewAdapter+Convenience.swift in Sources */,

--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
@@ -97,7 +97,7 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
      */
     open var collectionViewSections: [Section] = [] {
         willSet {
-            if collectionViewSections.unique(by: \.id).count != collectionViewSections.count {
+            guard collectionViewSections.map(\.id).isUnique() else {
                 fatalError(
                     """
                     The list of sections contains two or more sections with the same id.

--- a/SectionKit/Sources/Utility/Collection+IsUnique.swift
+++ b/SectionKit/Sources/Utility/Collection+IsUnique.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Collection where Element: Hashable {
+    internal func isUnique() -> Bool {
+        Set(self).count == count
+    }
+}

--- a/SectionKit/Sources/Utility/Sequence+Unique.swift
+++ b/SectionKit/Sources/Utility/Sequence+Unique.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-extension Sequence {
-    internal func unique<T: Hashable>(by selector: (Iterator.Element) throws -> T) rethrows -> [Iterator.Element] {
-        var seen: [T: Bool] = [:]
-        return try filter { seen.updateValue(true, forKey: try selector($0)) == nil }
-    }
-}


### PR DESCRIPTION
This PR fixes an issue that can be overlooked quite easily, which occurs when there are multiple sections with the same id. It is due to the adapter reusing the sectioncontroller from the previous array. If there are multiple ones with the same id the first instance is reused which may result in the same instance being used in multiple sections which creates huge issues when diffing the updates inside the section.