### PR TITLE
Execute all batch operations with completion

### DIFF
--- a/SectionKit/Sources/Utility/UICollectionView+Apply.swift
+++ b/SectionKit/Sources/Utility/UICollectionView+Apply.swift
@@ -12,9 +12,14 @@ extension UICollectionView {
     public func apply<T>(update: CollectionViewSectionUpdate<T>, at section: Int) {
         guard update.batchOperations.isNotEmpty else { return }
 
-        if case .none = window, let data = update.batchOperations.last?.data {
-            update.setData(data)
-            return reloadSections(IndexSet(integer: section))
+        // reload data when the collection wasn't added to a window yet
+        guard window != nil else {
+            for batchOperation in update.batchOperations {
+                update.setData(batchOperation.data)
+                reloadData()
+                batchOperation.completion?(false)
+            }
+            return
         }
 
         for batchOperation in update.batchOperations {
@@ -57,6 +62,8 @@ extension UICollectionView {
     @inlinable
     public func apply<T>(update: CollectionViewUpdate<T>) {
         guard update.batchOperations.isNotEmpty else { return }
+        
+        // reload data when the collection wasn't added to a window yet
         guard window != nil else {
             for batchOperation in update.batchOperations {
                 update.setData(batchOperation.data)


### PR DESCRIPTION
This PR adds refactors applying the changes to the `UICollectionView` when the collection isn't added to a `UIWindow` yet.
It now makes sure that all completion handlers are called in the correct order.