### PR TITLE
Add unit tests for `CollectionViewAdapter` conforming to `UICollectionViewDelegate`

### DIFF
--- a/SectionKit.xcodeproj/project.pbxproj
+++ b/SectionKit.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		5AA9D96126AAC53A00679D88 /* MockSectionDataSourcePrefetchingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9D96026AAC53A00679D88 /* MockSectionDataSourcePrefetchingDelegate.swift */; };
 		5AA9D96326AAC65200679D88 /* ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9D96226AAC65200679D88 /* ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift */; };
 		5AA9D96526AAC66500679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9D96426AAC66500679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift */; };
+		5AA9D96826AAC9AF00679D88 /* BaseCollectionViewAdapterUICollectionViewDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9D96726AAC9AF00679D88 /* BaseCollectionViewAdapterUICollectionViewDelegateTests.swift */; };
+		5AA9D96A26AACACF00679D88 /* MockSectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9D96926AACACF00679D88 /* MockSectionDelegate.swift */; };
+		5AA9D96C26AAD05400679D88 /* ListCollectionViewAdapterUICollectionViewDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9D96B26AAD05400679D88 /* ListCollectionViewAdapterUICollectionViewDelegateTests.swift */; };
+		5AA9D96E26AAD06100679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9D96D26AAD06100679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift */; };
 		5AB6642926A587AE004DC230 /* CollectionViewContextSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB6642826A587AE004DC230 /* CollectionViewContextSizeTests.swift */; };
 		5AB6643026A59626004DC230 /* BaseCollectionViewAdapterUICollectionViewDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB6642F26A59626004DC230 /* BaseCollectionViewAdapterUICollectionViewDataSourceTests.swift */; };
 		5AB6644426A85463004DC230 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB6644326A85463004DC230 /* Error.swift */; };
@@ -103,6 +107,10 @@
 		5AA9D96026AAC53A00679D88 /* MockSectionDataSourcePrefetchingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSectionDataSourcePrefetchingDelegate.swift; sourceTree = "<group>"; };
 		5AA9D96226AAC65200679D88 /* ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift; sourceTree = "<group>"; };
 		5AA9D96426AAC66500679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift; sourceTree = "<group>"; };
+		5AA9D96726AAC9AF00679D88 /* BaseCollectionViewAdapterUICollectionViewDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewAdapterUICollectionViewDelegateTests.swift; sourceTree = "<group>"; };
+		5AA9D96926AACACF00679D88 /* MockSectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSectionDelegate.swift; sourceTree = "<group>"; };
+		5AA9D96B26AAD05400679D88 /* ListCollectionViewAdapterUICollectionViewDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCollectionViewAdapterUICollectionViewDelegateTests.swift; sourceTree = "<group>"; };
+		5AA9D96D26AAD06100679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift; sourceTree = "<group>"; };
 		5AB6642826A587AE004DC230 /* CollectionViewContextSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContextSizeTests.swift; sourceTree = "<group>"; };
 		5AB6642F26A59626004DC230 /* BaseCollectionViewAdapterUICollectionViewDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewAdapterUICollectionViewDataSourceTests.swift; sourceTree = "<group>"; };
 		5AB6644326A85463004DC230 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -210,6 +218,16 @@
 			path = UICollectionViewDataSourcePrefetching;
 			sourceTree = "<group>";
 		};
+		5AA9D96626AAC99100679D88 /* UICollectionViewDelegate */ = {
+			isa = PBXGroup;
+			children = (
+				5AA9D96726AAC9AF00679D88 /* BaseCollectionViewAdapterUICollectionViewDelegateTests.swift */,
+				5AA9D96B26AAD05400679D88 /* ListCollectionViewAdapterUICollectionViewDelegateTests.swift */,
+				5AA9D96D26AAD06100679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift */,
+			);
+			path = UICollectionViewDelegate;
+			sourceTree = "<group>";
+		};
 		5AB6642A26A59589004DC230 /* CollectionViewContext */ = {
 			isa = PBXGroup;
 			children = (
@@ -233,6 +251,7 @@
 				5AB6644A26A86F7A004DC230 /* MockSectionController.swift */,
 				5AB6644826A86F4D004DC230 /* MockSectionDataSource.swift */,
 				5AA9D96026AAC53A00679D88 /* MockSectionDataSourcePrefetchingDelegate.swift */,
+				5AA9D96926AACACF00679D88 /* MockSectionDelegate.swift */,
 				5AA9D95126AAA5E000679D88 /* MockCollectionViewCell.swift */,
 				5AA9D95326AAA5EA00679D88 /* MockCollectionReusableView.swift */,
 				5AA9D95526AAA61700679D88 /* MockErrorHandler.swift */,
@@ -438,6 +457,7 @@
 				5AB6642A26A59589004DC230 /* CollectionViewContext */,
 				5AA9D95B26AABEDD00679D88 /* UICollectionViewDataSource */,
 				5AA9D95C26AABEEF00679D88 /* UICollectionViewDataSourcePrefetching */,
+				5AA9D96626AAC99100679D88 /* UICollectionViewDelegate */,
 			);
 			path = CollectionViewAdapter;
 			sourceTree = "<group>";
@@ -613,16 +633,20 @@
 			files = (
 				5AA9D95226AAA5E000679D88 /* MockCollectionViewCell.swift in Sources */,
 				5AB6643026A59626004DC230 /* BaseCollectionViewAdapterUICollectionViewDataSourceTests.swift in Sources */,
+				5AA9D96A26AACACF00679D88 /* MockSectionDelegate.swift in Sources */,
+				5AA9D96E26AAD06100679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift in Sources */,
 				5AE1761E2667DA7000D4DCE1 /* SequenceExtensionsTests.swift in Sources */,
 				5AA9D95626AAA61700679D88 /* MockErrorHandler.swift in Sources */,
 				5AA9D95A26AAA92600679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDataSourceTests.swift in Sources */,
 				5AB6642926A587AE004DC230 /* CollectionViewContextSizeTests.swift in Sources */,
 				5AE1761C2667DA7000D4DCE1 /* SectionBatchOperationTests.swift in Sources */,
+				5AA9D96826AAC9AF00679D88 /* BaseCollectionViewAdapterUICollectionViewDelegateTests.swift in Sources */,
 				5AA9D96126AAC53A00679D88 /* MockSectionDataSourcePrefetchingDelegate.swift in Sources */,
 				5AA9D95F26AABF1300679D88 /* BaseCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift in Sources */,
 				5AA9D95426AAA5EA00679D88 /* MockCollectionReusableView.swift in Sources */,
 				5AA9D96326AAC65200679D88 /* ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift in Sources */,
 				5AE1761B2667DA7000D4DCE1 /* SectionIndexPathTests.swift in Sources */,
+				5AA9D96C26AAD05400679D88 /* ListCollectionViewAdapterUICollectionViewDelegateTests.swift in Sources */,
 				5AA9D96526AAC66500679D88 /* SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift in Sources */,
 				5AB6644B26A86F7A004DC230 /* MockSectionController.swift in Sources */,
 				5AE1761D2667DA7000D4DCE1 /* SectionUpdateTests.swift in Sources */,

--- a/SectionKit.xcodeproj/xcshareddata/xcschemes/SectionKit.xcscheme
+++ b/SectionKit.xcodeproj/xcshareddata/xcschemes/SectionKit.xcscheme
@@ -55,6 +55,9 @@
                <Test
                   Identifier = "BaseCollectionViewAdapterUICollectionViewDataSourceTests">
                </Test>
+               <Test
+                  Identifier = "BaseCollectionViewAdapterUICollectionViewDelegateTests">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter+UICollectionViewDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter+UICollectionViewDelegate.swift
@@ -113,7 +113,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
         case UICollectionView.elementKindSectionFooter:
             delegate.willDisplay(footerView: view, at: sectionIndexPath, in: context)
 
-        default: break
+        default:
+            context.errorHandler(error: .unsupportedSupplementaryViewKind(elementKind: elementKind))
         }
     }
 
@@ -146,7 +147,8 @@ extension ListCollectionViewAdapter: UICollectionViewDelegate {
         case UICollectionView.elementKindSectionFooter:
             delegate.didEndDisplaying(footerView: view, at: sectionIndexPath, in: context)
 
-        default: break
+        default:
+            context.errorHandler(error: .unsupportedSupplementaryViewKind(elementKind: elementKind))
         }
     }
 

--- a/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter+UICollectionViewDelegate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter+UICollectionViewDelegate.swift
@@ -113,7 +113,8 @@ extension SingleSectionCollectionViewAdapter: UICollectionViewDelegate {
         case UICollectionView.elementKindSectionFooter:
             delegate.willDisplay(footerView: view, at: sectionIndexPath, in: context)
 
-        default: break
+        default:
+            context.errorHandler(error: .unsupportedSupplementaryViewKind(elementKind: elementKind))
         }
     }
 
@@ -146,7 +147,8 @@ extension SingleSectionCollectionViewAdapter: UICollectionViewDelegate {
         case UICollectionView.elementKindSectionFooter:
             delegate.didEndDisplaying(footerView: view, at: sectionIndexPath, in: context)
 
-        default: break
+        default:
+            context.errorHandler(error: .unsupportedSupplementaryViewKind(elementKind: elementKind))
         }
     }
 

--- a/SectionKit/Sources/SectionController/SectionIndexPath.swift
+++ b/SectionKit/Sources/SectionController/SectionIndexPath.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A struct containing the internal and external index of an item.
-public struct SectionIndexPath {
+public struct SectionIndexPath: Equatable {
     /// The index path of the item in the `UICollectionView`.
     public let indexInCollectionView: IndexPath
 

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/BaseCollectionViewAdapterUICollectionViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/BaseCollectionViewAdapterUICollectionViewDelegateTests.swift
@@ -1,0 +1,1319 @@
+@testable import SectionKit
+import UIKit
+import XCTest
+
+internal class BaseCollectionViewAdapterUICollectionViewDelegateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    internal func createCollectionView(
+        frame: CGRect = .zero,
+        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+    ) -> UICollectionView {
+        UICollectionView(frame: frame, collectionViewLayout: layout)
+    }
+
+    internal func createCollectionViewAdapter(
+        collectionView: UICollectionView,
+        sections: [Section] = [],
+        viewController: UIViewController? = nil,
+        scrollViewDelegate: UIScrollViewDelegate? = nil,
+        errorHandler: ErrorHandling = AssertionFailureErrorHandler()
+    ) throws -> CollectionViewAdapter & UICollectionViewDelegate {
+        fatalError("not implemented")
+    }
+
+    internal func testShouldHighlightItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._shouldHighlightItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldHighlightItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testShouldHighlightItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldHighlightItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+    }
+
+    internal func testDidHighlightItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didHighlightItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didHighlightItemAt: itemIndexPath.indexInCollectionView)
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidHighlightItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didHighlightItemAt: itemIndexPath.indexInCollectionView)
+    }
+
+    internal func testDidUnhighlightItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didUnhighlightItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didUnhighlightItemAt: itemIndexPath.indexInCollectionView)
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidUnhighlightItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didUnhighlightItemAt: itemIndexPath.indexInCollectionView)
+    }
+
+    internal func testShouldSelectItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._shouldSelectItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldSelectItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testShouldSelectItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldSelectItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+    }
+
+    internal func testShouldDeselectItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._shouldDeselectItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldDeselectItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testShouldDeselectItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldDeselectItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+    }
+
+    internal func testDidSelectItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didSelectItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didSelectItemAt: itemIndexPath.indexInCollectionView)
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidSelectItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didSelectItemAt: itemIndexPath.indexInCollectionView)
+    }
+
+    internal func testDidDeselectItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didDeselectItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didDeselectItemAt: itemIndexPath.indexInCollectionView)
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidDeselectItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didDeselectItemAt: itemIndexPath.indexInCollectionView)
+    }
+
+    internal func testWillDisplayCell() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemCell = MockCollectionViewCell()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._willDisplayCell = { cell, indexPath, _ in
+                            XCTAssert(cell === itemCell)
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, willDisplay: itemCell, forItemAt: itemIndexPath.indexInCollectionView)
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testWillDisplayCellWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemCell = MockCollectionViewCell()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, willDisplay: itemCell, forItemAt: itemIndexPath.indexInCollectionView)
+    }
+
+    internal func testWillDisplayHeaderView() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemHeaderView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._willDisplayHeaderView = { headerView, indexPath, _ in
+                            XCTAssert(headerView === itemHeaderView)
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            willDisplaySupplementaryView: itemHeaderView,
+            forElementKind: UICollectionView.elementKindSectionHeader,
+            at: itemIndexPath.indexInCollectionView
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testWillDisplayFooterView() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemFooterView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._willDisplayFooterView = { headerView, indexPath, _ in
+                            XCTAssert(headerView === itemFooterView)
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            willDisplaySupplementaryView: itemFooterView,
+            forElementKind: UICollectionView.elementKindSectionFooter,
+            at: itemIndexPath.indexInCollectionView
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testWillDisplaySupplementaryViewWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemHeaderView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            willDisplaySupplementaryView: itemHeaderView,
+            forElementKind: UICollectionView.elementKindSectionHeader,
+            at: itemIndexPath.indexInCollectionView
+        )
+    }
+
+    internal func testWillDisplaySupplementaryViewWithInvalidElementKind() throws {
+        let dataSourceExpectation = expectation(description: "Should not invoke delegate")
+        dataSourceExpectation.fulfill()
+        let errorExpectation = expectation(description: "Should invoke errorHandler")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemFooterView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._willDisplayHeaderView = { headerView, indexPath, _ in
+                            dataSourceExpectation.fulfill()
+                        }
+                        delegate._willDisplayFooterView = { headerView, indexPath, _ in
+                            dataSourceExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ],
+            errorHandler: MockErrorHandler { error in
+                guard case let .unsupportedSupplementaryViewKind(elementKind) = error, elementKind == "test" else {
+                    XCTFail("The error should be unsupportedSupplementaryViewKind")
+                    return
+                }
+                errorExpectation.fulfill()
+            }
+        )
+        adapter.collectionView?(
+            collectionView,
+            willDisplaySupplementaryView: itemFooterView,
+            forElementKind: "test",
+            at: itemIndexPath.indexInCollectionView
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidEndDisplayingCell() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemCell = MockCollectionViewCell()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didEndDisplayingCell = { cell, indexPath, _ in
+                            XCTAssert(cell === itemCell)
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didEndDisplaying: itemCell, forItemAt: itemIndexPath.indexInCollectionView)
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidEndDisplayingCellWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemCell = MockCollectionViewCell()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(collectionView, didEndDisplaying: itemCell, forItemAt: itemIndexPath.indexInCollectionView)
+    }
+
+    internal func testDidEndDisplayingHeaderView() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemHeaderView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didEndDisplayingHeaderView = { headerView, indexPath, _ in
+                            XCTAssert(headerView === itemHeaderView)
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            didEndDisplayingSupplementaryView: itemHeaderView,
+            forElementOfKind: UICollectionView.elementKindSectionHeader,
+            at: itemIndexPath.indexInCollectionView
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidEndDisplayingFooterView() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemFooterView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didEndDisplayingFooterView = { headerView, indexPath, _ in
+                            XCTAssert(headerView === itemFooterView)
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            didEndDisplayingSupplementaryView: itemFooterView,
+            forElementOfKind: UICollectionView.elementKindSectionFooter,
+            at: itemIndexPath.indexInCollectionView
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidEndDisplayingSupplementaryViewWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemHeaderView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            didEndDisplayingSupplementaryView: itemHeaderView,
+            forElementOfKind: UICollectionView.elementKindSectionHeader,
+            at: itemIndexPath.indexInCollectionView
+        )
+    }
+
+    internal func testDidEndDisplayingSupplementaryWithInvalidElementKind() throws {
+        let dataSourceExpectation = expectation(description: "Should not invoke delegate")
+        dataSourceExpectation.fulfill()
+        let errorExpectation = expectation(description: "Should invoke errorHandler")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemFooterView = MockCollectionReusableView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didEndDisplayingHeaderView = { headerView, indexPath, _ in
+                            dataSourceExpectation.fulfill()
+                        }
+                        delegate._didEndDisplayingFooterView = { headerView, indexPath, _ in
+                            dataSourceExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ],
+            errorHandler: MockErrorHandler { error in
+                guard case let .unsupportedSupplementaryViewKind(elementKind) = error, elementKind == "test" else {
+                    XCTFail("The error should be unsupportedSupplementaryViewKind")
+                    return
+                }
+                errorExpectation.fulfill()
+            }
+        )
+        adapter.collectionView?(
+            collectionView,
+            didEndDisplayingSupplementaryView: itemFooterView,
+            forElementOfKind: "test",
+            at: itemIndexPath.indexInCollectionView
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    // the availability attribute is needed to silence a warning
+    @available(iOS, introduced: 6.0, deprecated: 13.0)
+    internal func testShouldShowMenuForItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._shouldShowMenuForItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldShowMenuForItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    // the availability attribute is needed to silence a warning
+    @available(iOS, introduced: 6.0, deprecated: 13.0)
+    internal func testShouldShowMenuForItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, shouldShowMenuForItemAt: itemIndexPath.indexInCollectionView),
+            false
+        )
+    }
+
+    // the availability attribute is needed to silence a warning
+    @available(iOS, introduced: 6.0, deprecated: 13.0)
+    internal func testCanPerform() throws {
+        class Mock {
+            @objc
+            func perform() { }
+        }
+        let mockSender = Mock()
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._canPerform = { action, indexPath, sender, _ in
+                            XCTAssertEqual(action, #selector(Mock.perform))
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            XCTAssert((sender as? Mock) === mockSender)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                canPerformAction: #selector(Mock.perform),
+                forItemAt: itemIndexPath.indexInCollectionView,
+                withSender: mockSender
+            ),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    // the availability attribute is needed to silence a warning
+    @available(iOS, introduced: 6.0, deprecated: 13.0)
+    internal func testCanPerformWithoutDelegate() throws {
+        class Mock {
+            @objc
+            func perform() { }
+        }
+        let mockSender = Mock()
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                canPerformAction: #selector(Mock.perform),
+                forItemAt: itemIndexPath.indexInCollectionView,
+                withSender: mockSender
+            ),
+            false
+        )
+    }
+
+    // the availability attribute is needed to silence a warning
+    @available(iOS, introduced: 6.0, deprecated: 13.0)
+    internal func testPerform() throws {
+        class Mock {
+            @objc
+            func perform() { }
+        }
+        let mockSender = Mock()
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._perform = { action, indexPath, sender, _ in
+                            XCTAssertEqual(action, #selector(Mock.perform))
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            XCTAssert((sender as? Mock) === mockSender)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            performAction: #selector(Mock.perform),
+            forItemAt: itemIndexPath.indexInCollectionView,
+            withSender: mockSender
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    // the availability attribute is needed to silence a warning
+    @available(iOS, introduced: 6.0, deprecated: 13.0)
+    internal func testPerformWithoutDelegate() throws {
+        class Mock {
+            @objc
+            func perform() { }
+        }
+        let mockSender = Mock()
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            performAction: #selector(Mock.perform),
+            forItemAt: itemIndexPath.indexInCollectionView,
+            withSender: mockSender
+        )
+    }
+
+    internal func testTransitionLayoutForOldLayout() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        let fromLayout = UICollectionViewFlowLayout()
+        let toLayout = UICollectionViewFlowLayout()
+        let transitionLayout = try XCTUnwrap(
+            adapter.collectionView?(
+                collectionView,
+                transitionLayoutForOldLayout: fromLayout,
+                newLayout: toLayout
+            )
+        )
+        XCTAssert(transitionLayout.currentLayout === fromLayout)
+        XCTAssert(transitionLayout.nextLayout === toLayout)
+    }
+
+    internal func testCanFocusItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._canFocusItem = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, canFocusItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testCanFocusItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(collectionView, canFocusItemAt: itemIndexPath.indexInCollectionView),
+            true
+        )
+    }
+
+    // Not possible to instantiate `UICollectionViewFocusUpdateContext`
+//    internal func testShouldUpdateFocus() throws {
+//        let collectionView = createCollectionView()
+//        let adapter = try createCollectionViewAdapter(
+//            collectionView: collectionView,
+//            sections: [
+//                Section(id: "", model: "", controller: MockSectionController())
+//            ]
+//        )
+//        XCTAssertEqual(
+//            adapter.collectionView?(collectionView, shouldUpdateFocusIn: UICollectionViewFocusUpdateContext()),
+//            true
+//        )
+//    }
+
+    // Not possible to instantiate `UICollectionViewFocusUpdateContext`
+//    internal func testDidUpdateFocus() throws {
+//        let collectionView = createCollectionView()
+//        let adapter = try createCollectionViewAdapter(
+//            collectionView: collectionView,
+//            sections: [
+//                Section(id: "", model: "", controller: MockSectionController())
+//            ]
+//        )
+//        adapter.collectionView?(
+//            collectionView,
+//            didUpdateFocusIn: UICollectionViewFocusUpdateContext(),
+//            with: UIFocusAnimationCoordinator()
+//        )
+//    }
+
+    internal func testIndexPathForPreferredFocusedView() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        XCTAssertNil(adapter.indexPathForPreferredFocusedView?(in: collectionView))
+    }
+
+    internal func testTargetIndexPathForMoveFromItem() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        let fromIndexPath = IndexPath(item: 1, section: 2)
+        let toIndexPath = IndexPath(item: 4, section: 8)
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                targetIndexPathForMoveFromItemAt: fromIndexPath,
+                toProposedIndexPath: toIndexPath
+            ),
+            toIndexPath
+        )
+    }
+
+    internal func testTargetContentOffsetForProposedContentOffset() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        let offset = CGPoint(x: 1, y: 2)
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                targetContentOffsetForProposedContentOffset: offset
+            ),
+            offset
+        )
+    }
+
+    internal func testShouldSpringLoadItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let mockContext = MockSpringLoadedInteractionContext()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._shouldSpringLoadItem = { indexPath, context, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            XCTAssert(context === mockContext)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                shouldSpringLoadItemAt: itemIndexPath.indexInCollectionView,
+                with: mockContext
+            ),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testShouldSpringLoadItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let mockContext = MockSpringLoadedInteractionContext()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                shouldSpringLoadItemAt: itemIndexPath.indexInCollectionView,
+                with: mockContext
+            ),
+            true
+        )
+    }
+
+    internal func testShouldBeginMultipleSelectionInteraction() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._shouldBeginMultipleSelectionInteraction = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                            return true
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                shouldBeginMultipleSelectionInteractionAt: itemIndexPath.indexInCollectionView
+            ),
+            true
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testShouldBeginMultipleSelectionInteractionWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertEqual(
+            adapter.collectionView?(
+                collectionView,
+                shouldBeginMultipleSelectionInteractionAt: itemIndexPath.indexInCollectionView
+            ),
+            false
+        )
+    }
+
+    internal func testDidBeginMultipleSelectionInteraction() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._didBeginMultipleSelectionInteraction = { indexPath, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            testExpectation.fulfill()
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            didBeginMultipleSelectionInteractionAt: itemIndexPath.indexInCollectionView
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testDidBeginMultipleSelectionInteractionWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            didBeginMultipleSelectionInteractionAt: itemIndexPath.indexInCollectionView
+        )
+    }
+
+    internal func testDidEndMultipleSelectionInteraction() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        adapter.collectionViewDidEndMultipleSelectionInteraction?(collectionView)
+    }
+
+    internal func testContextMenuConfigurationForItem() throws {
+        let testExpectation = expectation(description: "Should invoke delegate")
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemPoint = CGPoint(x: 1, y: 2)
+        let itemConfiguration = UIContextMenuConfiguration()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = {
+                        let delegate = MockSectionDelegate()
+                        delegate._contextMenuConfigurationForItem = { indexPath, point, _ in
+                            XCTAssertEqual(indexPath, itemIndexPath)
+                            XCTAssertEqual(point, itemPoint)
+                            testExpectation.fulfill()
+                            return itemConfiguration
+                        }
+                        return delegate
+                    }()
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssert(
+            adapter.collectionView?(
+                collectionView,
+                contextMenuConfigurationForItemAt: itemIndexPath.indexInCollectionView,
+                point: itemPoint
+            ) === itemConfiguration
+        )
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testContextMenuConfigurationForItemWithoutDelegate() throws {
+        let collectionView = createCollectionView()
+        let itemIndexPath = SectionIndexPath(IndexPath(item: 0, section: 0))
+        let itemPoint = CGPoint(x: 1, y: 2)
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: {
+                    let sectionController = MockSectionController()
+                    sectionController.delegate = nil
+                    return sectionController
+                })
+            ]
+        )
+        XCTAssertNil(
+            adapter.collectionView?(
+                collectionView,
+                contextMenuConfigurationForItemAt: itemIndexPath.indexInCollectionView,
+                point: itemPoint
+            )
+        )
+    }
+
+    internal func testPreviewForHighlightingContextMenuWithConfiguration() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        XCTAssertNil(
+            adapter.collectionView?(
+                collectionView,
+                previewForHighlightingContextMenuWithConfiguration: UIContextMenuConfiguration()
+            )
+        )
+    }
+
+    internal func testPreviewForDismissingContextMenuWithConfiguration() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        XCTAssertNil(
+            adapter.collectionView?(
+                collectionView,
+                previewForDismissingContextMenuWithConfiguration: UIContextMenuConfiguration()
+            )
+        )
+    }
+
+    internal func testWillPerformPreviewActionForMenu() throws {
+        let collectionView = createCollectionView()
+        let adapter = try createCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [
+                Section(id: "", model: "", controller: MockSectionController())
+            ]
+        )
+        adapter.collectionView?(
+            collectionView,
+            willPerformPreviewActionForMenuWith: UIContextMenuConfiguration(),
+            animator: MockContextMenuInteractionCommitAnimating()
+        )
+    }
+}
+
+private final class MockSpringLoadedInteractionContext: NSObject, UISpringLoadedInteractionContext {
+    var state: UISpringLoadedInteractionEffectState = .activated
+
+    var targetView: UIView?
+
+    var targetItem: Any?
+
+    func location(in view: UIView?) -> CGPoint {
+        .zero
+    }
+}
+
+private class MockContextMenuInteractionCommitAnimating: NSObject, UIContextMenuInteractionCommitAnimating {
+    var preferredCommitStyle: UIContextMenuInteractionCommitStyle = .dismiss
+
+    var previewViewController: UIViewController?
+
+    func addAnimations(_ animations: @escaping () -> Void) { }
+
+    func addCompletion(_ completion: @escaping () -> Void) { }
+}

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/ListCollectionViewAdapterUICollectionViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/ListCollectionViewAdapterUICollectionViewDelegateTests.swift
@@ -1,0 +1,21 @@
+@testable import SectionKit
+import UIKit
+import XCTest
+
+internal final class ListCollectionViewAdapterUICollectionViewDelegateTests: BaseCollectionViewAdapterUICollectionViewDelegateTests {
+    override internal func createCollectionViewAdapter(
+        collectionView: UICollectionView,
+        sections: [Section] = [],
+        viewController: UIViewController? = nil,
+        scrollViewDelegate: UIScrollViewDelegate? = nil,
+        errorHandler: ErrorHandling = AssertionFailureErrorHandler()
+    ) throws -> CollectionViewAdapter & UICollectionViewDelegate {
+        ListCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: sections,
+            viewController: viewController,
+            scrollViewDelegate: scrollViewDelegate,
+            errorHandler: errorHandler
+        )
+    }
+}

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift
@@ -1,0 +1,22 @@
+@testable import SectionKit
+import UIKit
+import XCTest
+
+internal final class SingleSectionCollectionViewAdapterUICollectionViewDelegateTests: BaseCollectionViewAdapterUICollectionViewDelegateTests {
+    override internal func createCollectionViewAdapter(
+        collectionView: UICollectionView,
+        sections: [Section] = [],
+        viewController: UIViewController? = nil,
+        scrollViewDelegate: UIScrollViewDelegate? = nil,
+        errorHandler: ErrorHandling = AssertionFailureErrorHandler()
+    ) throws -> CollectionViewAdapter & UICollectionViewDelegate {
+        try XCTSkipIf(sections.count > 1, "A test with more than one section is skipped.")
+        return SingleSectionCollectionViewAdapter(
+            collectionView: collectionView,
+            section: sections.first,
+            viewController: viewController,
+            scrollViewDelegate: scrollViewDelegate,
+            errorHandler: errorHandler
+        )
+    }
+}

--- a/SectionKit/Tests/TestUtilities/MockSectionDelegate.swift
+++ b/SectionKit/Tests/TestUtilities/MockSectionDelegate.swift
@@ -1,0 +1,308 @@
+import SectionKit
+import UIKit
+import XCTest
+
+internal class MockSectionDelegate: SectionDelegate {
+    // MARK: - shouldHighlightItem
+
+    internal typealias ShouldHighlightItemBlock = (SectionIndexPath, CollectionViewContext) -> Bool
+
+    internal var _shouldHighlightItem: ShouldHighlightItemBlock = { _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func shouldHighlightItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) -> Bool {
+        _shouldHighlightItem(indexPath, context)
+    }
+
+    // MARK: - didHighlightItem
+
+    internal typealias DidHighlightItemBlock = (SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didHighlightItem: DidHighlightItemBlock = { _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didHighlightItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) {
+        _didHighlightItem(indexPath, context)
+    }
+
+    // MARK: - didUnhighlightItem
+
+    internal typealias DidUnhighlightItemBlock = (SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didUnhighlightItem: DidUnhighlightItemBlock = { _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didUnhighlightItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) {
+        _didUnhighlightItem(indexPath, context)
+    }
+
+    // MARK: - shouldSelectItem
+
+    internal typealias ShouldSelectItemBlock = (SectionIndexPath, CollectionViewContext) -> Bool
+
+    internal var _shouldSelectItem: ShouldSelectItemBlock = { _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func shouldSelectItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) -> Bool {
+        _shouldSelectItem(indexPath, context)
+    }
+
+    // MARK: - shouldDeselectItem
+
+    internal typealias ShouldDeselectItemBlock = (SectionIndexPath, CollectionViewContext) -> Bool
+
+    internal var _shouldDeselectItem: ShouldDeselectItemBlock = { _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func shouldDeselectItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) -> Bool {
+        _shouldDeselectItem(indexPath, context)
+    }
+
+    // MARK: - didSelectItem
+
+    internal typealias DidSelectItemBlock = (SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didSelectItem: DidSelectItemBlock = { _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didSelectItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) {
+        _didSelectItem(indexPath, context)
+    }
+
+    // MARK: - didDeselectItem
+
+    internal typealias DidDeselectItemBlock = (SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didDeselectItem: DidDeselectItemBlock = { _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didDeselectItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) {
+        _didDeselectItem(indexPath, context)
+    }
+
+    // MARK: - willDisplay:cell
+
+    internal typealias WillDisplayCellBlock = (UICollectionViewCell, SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _willDisplayCell: WillDisplayCellBlock = { _, _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func willDisplay(
+        cell: UICollectionViewCell,
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) {
+        _willDisplayCell(cell, indexPath, context)
+    }
+
+    // MARK: - willDisplay:headerView
+
+    internal typealias WillDisplayHeaderViewBlock = (UICollectionReusableView, SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _willDisplayHeaderView: WillDisplayHeaderViewBlock = { _, _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func willDisplay(
+        headerView: UICollectionReusableView,
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) {
+        _willDisplayHeaderView(headerView, indexPath, context)
+    }
+
+    // MARK: - willDisplay:footerView
+
+    internal typealias WillDisplayFooterViewBlock = (UICollectionReusableView, SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _willDisplayFooterView: WillDisplayFooterViewBlock = { _, _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func willDisplay(
+        footerView: UICollectionReusableView,
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) {
+        _willDisplayFooterView(footerView, indexPath, context)
+    }
+
+    // MARK: - didEndDisplaying:cell
+
+    internal typealias DidEndDisplayingCellBlock = (UICollectionViewCell, SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didEndDisplayingCell: DidEndDisplayingCellBlock = { _, _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didEndDisplaying(
+        cell: UICollectionViewCell,
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) {
+        _didEndDisplayingCell(cell, indexPath, context)
+    }
+
+    // MARK: - didEndDisplaying:headerView
+
+    internal typealias DidEndDisplayingHeaderViewBlock = (UICollectionReusableView, SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didEndDisplayingHeaderView: DidEndDisplayingHeaderViewBlock = { _, _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didEndDisplaying(
+        headerView: UICollectionReusableView,
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) {
+        _didEndDisplayingHeaderView(headerView, indexPath, context)
+    }
+
+    // MARK: - didEndDisplaying:footerView
+
+    internal typealias DidEndDisplayingFooterViewBlock = (UICollectionReusableView, SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didEndDisplayingFooterView: DidEndDisplayingFooterViewBlock = { _, _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didEndDisplaying(
+        footerView: UICollectionReusableView,
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) {
+        _didEndDisplayingFooterView(footerView, indexPath, context)
+    }
+
+    // MARK: - shouldShowMenuForItem
+
+    internal typealias ShouldShowMenuForItemBlock = (SectionIndexPath, CollectionViewContext) -> Bool
+
+    internal var _shouldShowMenuForItem: ShouldShowMenuForItemBlock = { _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func shouldShowMenuForItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) -> Bool {
+        _shouldShowMenuForItem(indexPath, context)
+    }
+
+    // MARK: - canPerform
+
+    internal typealias CanPerformBlock = (Selector, SectionIndexPath, Any?, CollectionViewContext) -> Bool
+
+    internal var _canPerform: CanPerformBlock = { _, _, _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func canPerform(
+        action: Selector,
+        forItemAt indexPath: SectionIndexPath,
+        withSender sender: Any?,
+        in context: CollectionViewContext
+    ) -> Bool {
+        _canPerform(action, indexPath, sender, context)
+    }
+
+    // MARK: - perform
+
+    internal typealias PerformBlock = (Selector, SectionIndexPath, Any?, CollectionViewContext) -> Void
+
+    internal var _perform: PerformBlock = { _, _, _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func perform(
+        action: Selector,
+        forItemAt indexPath: SectionIndexPath,
+        withSender sender: Any?,
+        in context: CollectionViewContext
+    ) {
+        _perform(action, indexPath, sender, context)
+    }
+
+    // MARK: - canFocusItem
+
+    internal typealias CanFocusItemBlock = (SectionIndexPath, CollectionViewContext) -> Bool
+
+    internal var _canFocusItem: CanFocusItemBlock = { _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func canFocusItem(at indexPath: SectionIndexPath, in context: CollectionViewContext) -> Bool {
+        _canFocusItem(indexPath, context)
+    }
+
+    // MARK: - shouldSpringLoadItem
+
+    internal typealias ShouldSpringLoadItemBlock = (SectionIndexPath, UISpringLoadedInteractionContext, CollectionViewContext) -> Bool
+
+    internal var _shouldSpringLoadItem: ShouldSpringLoadItemBlock = { _, _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func shouldSpringLoadItem(
+        at indexPath: SectionIndexPath,
+        with interactionContext: UISpringLoadedInteractionContext,
+        in context: CollectionViewContext
+    ) -> Bool {
+        _shouldSpringLoadItem(indexPath, interactionContext, context)
+    }
+
+    // MARK: - shouldBeginMultipleSelectionInteraction
+
+    internal typealias ShouldBeginMultipleSelectionInteractionBlock = (SectionIndexPath, CollectionViewContext) -> Bool
+
+    internal var _shouldBeginMultipleSelectionInteraction: ShouldBeginMultipleSelectionInteractionBlock = { _, _ in
+        XCTFail("not implemented")
+        return false
+    }
+
+    internal func shouldBeginMultipleSelectionInteraction(at indexPath: SectionIndexPath, in context: CollectionViewContext) -> Bool {
+        _shouldBeginMultipleSelectionInteraction(indexPath, context)
+    }
+
+    // MARK: - didBeginMultipleSelectionInteraction
+
+    internal typealias DidBeginMultipleSelectionInteractionBlock = (SectionIndexPath, CollectionViewContext) -> Void
+
+    internal var _didBeginMultipleSelectionInteraction: DidBeginMultipleSelectionInteractionBlock = { _, _ in
+        XCTFail("not implemented")
+    }
+
+    internal func didBeginMultipleSelectionInteraction(at indexPath: SectionIndexPath, in context: CollectionViewContext) {
+        _didBeginMultipleSelectionInteraction(indexPath, context)
+    }
+
+    // MARK: - contextMenuConfigurationForItem
+
+    internal typealias ContextMenuConfigurationForItemBlock = (SectionIndexPath, CGPoint, CollectionViewContext) -> UIContextMenuConfiguration?
+
+    internal var _contextMenuConfigurationForItem: ContextMenuConfigurationForItemBlock = { _, _, _ in
+        XCTFail("not implemented")
+        return nil
+    }
+
+    internal func contextMenuConfigurationForItem(
+        at indexPath: SectionIndexPath,
+        point: CGPoint,
+        in context: CollectionViewContext
+    ) -> UIContextMenuConfiguration? {
+        _contextMenuConfigurationForItem(indexPath, point, context)
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for the `UICollectionViewDelegate` conformance of `ListCollectionViewAdapter` and `SingleSectionCollectionViewAdapter`.

It also adapts the implementation to use the newly introduced `errorHandler`.