### PR TITLE
Fix version of SwiftPM integration in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To see SectionKit in action please check out the [example project](Example).
 On the package:
 ```swift
 dependencies: [
-    .package(name: "SectionKit", url: "https://github.com/traderepublic/SectionKit", from: "1.0")
+    .package(name: "SectionKit", url: "https://github.com/traderepublic/SectionKit", from: "1.0.0")
 ]
 ```
 


### PR DESCRIPTION
This PR changes the SwiftPM version from `1.0` to `1.0.0`, because it needs to be a full version string.