### PR TITLE
Add vanilla swift example that showcases updating the list of items

### DIFF
--- a/Example/Examples/Sources/Examples/ExampleList/ExampleListCoordinator+Presentable.swift
+++ b/Example/Examples/Sources/Examples/ExampleList/ExampleListCoordinator+Presentable.swift
@@ -27,6 +27,15 @@ extension ExampleListCoordinator: Presentable {
                             navigationController: navigationController,
                             presentable: NumbersCoordinator(navigationController: navigationController)
                         )
+                    ),
+                    ExampleViewModel(
+                        name: "Emojis",
+                        description: "An MVVM-C example using a SingleSectionCollectionViewAdapter that shows a single FoundationDiffingListSectionController."
+                            + " It has a shuffle button and the FoundationDiffingListSectionController is updated by invalidating the dataSource.",
+                        navigation: ExampleCoordinator(
+                            navigationController: navigationController,
+                            presentable: VanillaSwiftExamples.EmojisCoordinator(navigationController: navigationController)
+                        )
                     )
                 ]
             ),
@@ -41,7 +50,7 @@ extension ExampleListCoordinator: Presentable {
                             + " It has a shuffle button and the ListSectionController is updated with a binding.",
                         navigation: ExampleCoordinator(
                             navigationController: navigationController,
-                            presentable: EmojisCoordinator(navigationController: navigationController)
+                            presentable: ReactiveSwiftExamples.EmojisCoordinator(navigationController: navigationController)
                         )
                     )
                 ]

--- a/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojiCoordinator.swift
+++ b/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojiCoordinator.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+public struct EmojisCoordinator {
+    internal unowned let navigationController: UINavigationController
+
+    public init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+}

--- a/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisCoordinator+Presentable.swift
+++ b/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisCoordinator+Presentable.swift
@@ -1,0 +1,14 @@
+import UIKit
+import Utilities
+
+extension EmojisCoordinator: Presentable {
+    private func makeViewController() -> UIViewController {
+        let viewModel = EmojisViewModel()
+        return EmojisViewController(viewModel: viewModel)
+    }
+
+    @discardableResult
+    public func present(segue: NavigationSegue) -> NavigationSegue.RewindAction {
+        segue.invoke(with: makeViewController())
+    }
+}

--- a/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisSectionController.swift
+++ b/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisSectionController.swift
@@ -1,0 +1,40 @@
+import SectionKit
+import UIKit
+import Utilities
+
+internal final class EmojisSectionController: FoundationDiffingListSectionController<EmojisViewModelType, String> {
+    override func items(for model: EmojisViewModelType) -> [String] {
+        model.emojis
+    }
+
+    override internal func cellForItem(
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) -> UICollectionViewCell {
+        let cell: LabelCell = context.dequeueReusableCell(for: indexPath)
+        cell.label.text = items[indexPath]
+        return cell
+    }
+
+    override internal func sizeForItem(
+        at indexPath: SectionIndexPath,
+        using layout: UICollectionViewLayout,
+        in context: CollectionViewContext
+    ) -> CGSize {
+        CGSize(width: 100, height: 100)
+    }
+
+    override internal func shouldHighlightItem(
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) -> Bool {
+        false
+    }
+
+    override internal func shouldSelectItem(
+        at indexPath: SectionIndexPath,
+        in context: CollectionViewContext
+    ) -> Bool {
+        false
+    }
+}

--- a/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisViewController.swift
+++ b/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisViewController.swift
@@ -1,0 +1,68 @@
+import UIKit
+import SectionKit
+
+internal final class EmojisViewController: UIViewController {
+    private var viewModel: EmojisViewModelType {
+        didSet {
+            // `shufflePressed` mutates the viewmodel and thus invokes this `didSet` observer.
+            // If the viewmodel is a class, the invalidation of the datasource needs to be performed with another solution, e.g. weak delegate.
+            collectionViewAdapter.invalidateDataSource()
+        }
+    }
+
+    private var collectionViewAdapter: CollectionViewAdapter!
+
+    private let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumInteritemSpacing = .zero
+        layout.minimumLineSpacing = .zero
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .systemBackground
+        collectionView.alwaysBounceVertical = true
+        return collectionView
+    }()
+
+    internal init(viewModel: EmojisViewModelType) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required internal init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override internal func loadView() {
+        view = collectionView
+    }
+
+    override internal func viewDidLoad() {
+        super.viewDidLoad()
+        title = viewModel.title
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .refresh,
+            target: self,
+            action: #selector(shufflePressed)
+        )
+        collectionViewAdapter = SingleSectionCollectionViewAdapter(
+            collectionView: collectionView,
+            dataSource: self
+        )
+    }
+
+    @objc
+    private func shufflePressed() {
+        viewModel.shufflePressed()
+    }
+}
+
+extension EmojisViewController: SingleSectionCollectionViewAdapterDataSource {
+    func section(for adapter: CollectionViewAdapter) -> Section? {
+        let sectionModel = viewModel
+        return Section(
+            id: "emojis",
+            model: sectionModel,
+            controller: EmojisSectionController(model: sectionModel)
+        )
+    }
+}

--- a/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisViewModel.swift
+++ b/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Emojis/EmojisViewModel.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+internal typealias EmojisViewModelType = EmojisViewModelInputs & EmojisViewModelOutputs
+
+internal protocol EmojisViewModelInputs {
+    mutating func shufflePressed()
+}
+
+internal protocol EmojisViewModelOutputs {
+    var title: String { get }
+    var emojis: [String] { get }
+}
+
+internal struct EmojisViewModel: EmojisViewModelType {
+    internal let title = "Emojis"
+    internal var emojis = ["😀", "😃", "😄", "😁", "😆", "😅", "😂", "🤣", "🥲", "☺️", "😊", "😇", "🙂", "🙃", "😉"]
+
+    mutating func shufflePressed() {
+        emojis.shuffle()
+    }
+}


### PR DESCRIPTION
This PR adds another version of the emoji example, but it is implemented without using ReactiveSwift, to showcase how reloading a section with animated updates could be performed without using a reactive framework.