### PR TITLE
Fix ListCollectionViewAdapter init call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ final class MyCollectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         collectionViewAdapter = ListCollectionViewAdapter(
-            viewController: self, 
             collectionView: collectionView,
-            dataSource: self // no worries, we're going to add conformance to the protocol in a bit
+            dataSource: self, // no worries, we're going to add conformance to the protocol in a bit
+            viewController: self
         )
     }
 }


### PR DESCRIPTION
Fix ListCollectionViewAdapter init call in the README to match the parameters order change of 7aaff09 .