### PR TITLE
Improve performance of reusing SectionControllers by creating temporary dictionary

### DIFF
--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
@@ -140,8 +140,9 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
     open var sections: [Section] {
         get { collectionViewSections }
         set {
+            let existingSections = Dictionary(collectionViewSections.map { ($0.id, $0) }) { first, _ in first }
             for newSection in newValue {
-                guard let existingSection = collectionViewSections.first(where: { $0.id == newSection.id }) else {
+                guard let existingSection = existingSections[newSection.id] else {
                     continue
                 }
                 let existingController = existingSection.controller


### PR DESCRIPTION
This PR improves the performance of the SectionController reusing logic from `O(m * n)` to `O(m + n)`. 

Previously, for every section in the new list, a section with the same id was searched in the old list, meaning the old list was iterated for every item in the new list. Now this PR creates a temporary dictionary which offers constant time lookups and reduces the effort to one iteration of the old list.