### PR TITLE
Fix type error in example project after upgrading Xcode version

### DIFF
--- a/Example/ReactiveSwiftExamples/Sources/ReactiveSwiftExamples/Emojis/EmojisViewModel.swift
+++ b/Example/ReactiveSwiftExamples/Sources/ReactiveSwiftExamples/Emojis/EmojisViewModel.swift
@@ -19,7 +19,7 @@ internal struct EmojisViewModel: EmojisViewModelType {
 
     internal init() {
         let emojisList = ["😀", "😃", "😄", "😁", "😆", "😅", "😂", "🤣", "🥲", "☺️", "😊", "😇", "🙂", "🙃", "😉"]
-        let emojiViewModels = emojisList.map(EmojiViewModel.init)
+        let emojiViewModels: [EmojiViewModelType] = emojisList.map(EmojiViewModel.init)
         emojis = Property(
             initial: emojiViewModels,
             then: shufflePressedSignal.scan(into: emojiViewModels) { viewModels, _ in viewModels.shuffle() }


### PR DESCRIPTION
This PR fixes a type error that occurs after upgrading the Xcode version (the compiler can't implicitly downcast the array anymore).