### PR TITLE
SingleModelSectionController: Reload entire section when model is changed

### DIFF
--- a/SectionKit/Sources/SectionController/Generic/SingleModelSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/SingleModelSectionController.swift
@@ -2,13 +2,11 @@ import UIKit
 
 /**
  A `SectionController` that displays data of a single model. Unless overridden, `numberOfItems` will always be `1`
- and a change to its `model` will perform a call to `reloadItems(at:)`.
+ and a change to its `model` will perform a call to `reloadSections(_:)`.
 
  This `SectionController` is typically used when there are one or multiple **different** cells from
  a single model. If however all items are the semantically similar and one could derive an array of models,
  it is recommended to use `ListSectionController` instead.
-
- - Warning: If `numberOfItems` is overridden, `calculateUpdate(from:to:)` needs to be overridden as well.
  */
 open class SingleModelSectionController<Model>: BaseSectionController {
     /**
@@ -71,7 +69,6 @@ open class SingleModelSectionController<Model>: BaseSectionController {
         CollectionViewSectionUpdate(
             controller: self,
             data: newData,
-            reloads: [0],
             setData: { self.collectionViewModel = $0 }
         )
     }

--- a/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
@@ -502,6 +502,10 @@ internal final class ListCollectionViewAdapterTests: XCTestCase {
         let update = try XCTUnwrap(adapter.calculateUpdate(from: [], to: []))
         XCTAssertEqual(update.batchOperations.count, 1)
         let batchOperation = update.batchOperations.first!
+        XCTAssert(batchOperation.deletes.isEmpty)
+        XCTAssert(batchOperation.inserts.isEmpty)
+        XCTAssert(batchOperation.reloads.isEmpty)
+        XCTAssert(batchOperation.moves.isEmpty)
         XCTAssert(update.shouldReload(batchOperation))
     }
 

--- a/SectionKit/Tests/CollectionViewAdapter/SingleSectionCollectionViewAdapterTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/SingleSectionCollectionViewAdapterTests.swift
@@ -482,6 +482,7 @@ internal final class SingleSectionCollectionViewAdapterTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromSomeToSomeWithADifferentId() throws {
@@ -499,6 +500,7 @@ internal final class SingleSectionCollectionViewAdapterTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssertEqual(batchOperation.reloads, [0])
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromNoneToSome() throws {
@@ -516,6 +518,7 @@ internal final class SingleSectionCollectionViewAdapterTests: XCTestCase {
         XCTAssertEqual(batchOperation.inserts, [0])
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromSomeToNone() throws {
@@ -533,6 +536,7 @@ internal final class SingleSectionCollectionViewAdapterTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromNoneToNone() throws {
@@ -545,6 +549,7 @@ internal final class SingleSectionCollectionViewAdapterTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateHasCorrectData() throws {

--- a/SectionKit/Tests/SectionController/SingleItemSectionControllerTests.swift
+++ b/SectionKit/Tests/SectionController/SingleItemSectionControllerTests.swift
@@ -121,6 +121,7 @@ internal final class SingleItemSectionControllerTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromSomeToSomeWithDifferentItems() throws {
@@ -137,6 +138,7 @@ internal final class SingleItemSectionControllerTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssertEqual(batchOperation.reloads, [0])
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromNoneToSome() throws {
@@ -153,6 +155,7 @@ internal final class SingleItemSectionControllerTests: XCTestCase {
         XCTAssertEqual(batchOperation.inserts, [0])
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromSomeToNone() throws {
@@ -169,6 +172,7 @@ internal final class SingleItemSectionControllerTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testCalculateUpdateFromNoneToNone() throws {
@@ -185,6 +189,7 @@ internal final class SingleItemSectionControllerTests: XCTestCase {
         XCTAssert(batchOperation.inserts.isEmpty)
         XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssertFalse(update.shouldReload(batchOperation))
     }
 
     internal func testNumberOfItemsWithItem() {

--- a/SectionKit/Tests/SectionController/SingleModelSectionControllerTests.swift
+++ b/SectionKit/Tests/SectionController/SingleModelSectionControllerTests.swift
@@ -43,8 +43,9 @@ internal final class SingleModelSectionControllerTests: XCTestCase {
         let batchOperation = update.batchOperations.first!
         XCTAssert(batchOperation.deletes.isEmpty)
         XCTAssert(batchOperation.inserts.isEmpty)
-        XCTAssertEqual(batchOperation.reloads, [0])
+        XCTAssert(batchOperation.reloads.isEmpty)
         XCTAssert(batchOperation.moves.isEmpty)
+        XCTAssert(update.shouldReload(batchOperation))
     }
 
     internal func testNumberOfItems() {


### PR DESCRIPTION
This PR changes the update of the `SingleModelSectionController` so by default it reloads the entire section instead of only the first item. This fixes a common pitfall when overriding `numberOfItems` to return a different number than `1`.