### PR TITLE
Check for duplicates in sections property as well

### DIFF
--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
@@ -140,8 +140,9 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
     open var sections: [Section] {
         get { collectionViewSections }
         set {
+            let uniqueNewSections = filterDuplicateSectionIds(sections: newValue)
             let existingSections = Dictionary(collectionViewSections.map { ($0.id, $0) }) { first, _ in first }
-            for newSection in newValue {
+            for newSection in uniqueNewSections {
                 guard let existingSection = existingSections[newSection.id] else {
                     continue
                 }
@@ -149,8 +150,8 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
                 newSection.controller = existingController
                 existingController.didUpdate(model: newSection.model)
             }
-            guard let update = calculateUpdate(from: collectionViewSections, to: newValue) else {
-                collectionViewSections = newValue
+            guard let update = calculateUpdate(from: collectionViewSections, to: uniqueNewSections) else {
+                collectionViewSections = uniqueNewSections
                 return
             }
             context.apply(update: update)

--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
@@ -143,10 +143,9 @@ open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
             let uniqueNewSections = filterDuplicateSectionIds(sections: newValue)
             let existingSections = Dictionary(collectionViewSections.map { ($0.id, $0) }) { first, _ in first }
             for newSection in uniqueNewSections {
-                guard let existingSection = existingSections[newSection.id] else {
+                guard let existingController = existingSections[newSection.id]?.controller else {
                     continue
                 }
-                let existingController = existingSection.controller
                 newSection.controller = existingController
                 existingController.didUpdate(model: newSection.model)
             }

--- a/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
@@ -371,7 +371,6 @@ internal final class ListCollectionViewAdapterTests: XCTestCase {
     }
 
     internal func testSectionsPropertyFiltersDuplicateSectionsAndInvokesDidUpdateOnlyOnce() {
-        let errorHandlerExpectation = expectation(description: "Should invoke errorHandler")
         let didUpdateExpectation = expectation(description: "Should invoke SectionController.didUpdate exactly once")
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         let sectionId = "test"
@@ -400,7 +399,7 @@ internal final class ListCollectionViewAdapterTests: XCTestCase {
         let adapter = ListCollectionViewAdapter(
             collectionView: collectionView,
             sections: [initialSection],
-            errorHandler: MockErrorHandler()
+            errorHandler: MockErrorHandler { _, _ in }
         )
         adapter.sections = [firstSection, secondSection]
         XCTAssertEqual(adapter.sections.count, 1)

--- a/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
@@ -346,7 +346,7 @@ internal final class ListCollectionViewAdapterTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    internal func testConsecutiveSectionsFiltersDuplicateSectionsAndInvokeErrorHandler() {
+    internal func testSectionsPropertyFiltersDuplicateSectionsAndInvokesErrorHandler() {
         let testExpectation = expectation(description: "Should invoke errorHandler")
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         let firstSection = Section(id: "", model: "", controller: MockSectionController())
@@ -363,6 +363,44 @@ internal final class ListCollectionViewAdapterTests: XCTestCase {
                 XCTAssertEqual(severity, .nonCritical)
                 testExpectation.fulfill()
             }
+        )
+        adapter.sections = [firstSection, secondSection]
+        XCTAssertEqual(adapter.sections.count, 1)
+        XCTAssert(adapter.sections.first === firstSection)
+        waitForExpectations(timeout: 1)
+    }
+
+    internal func testSectionsPropertyFiltersDuplicateSectionsAndInvokesDidUpdateOnlyOnce() {
+        let errorHandlerExpectation = expectation(description: "Should invoke errorHandler")
+        let didUpdateExpectation = expectation(description: "Should invoke SectionController.didUpdate exactly once")
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        let sectionId = "test"
+
+        /*
+         The initial array only contains the `initialSection` and the array is then updated with `firstSection` and
+         `secondSection`. All three sections have the same id and the expected behaviour would be, that the initial
+         sectioncontroller is reused when updating the array. When setting `[firstSection, secondSection]`, the code
+         should filter out `secondSection` and subsequently call `didUpdate` only once.
+         */
+
+        let createInitialSectionController: () -> SectionController = {
+             let sectionController = MockSectionController()
+             sectionController._didUpdate = { _ in didUpdateExpectation.fulfill() }
+             return sectionController
+         }
+        let initialSection = Section(id: sectionId, model: "", controller: createInitialSectionController)
+
+        let createConsecutiveSectionController: () -> SectionController = {
+            XCTFail("Should reuse initial sectioncontroller")
+            return MockSectionController()
+        }
+        let firstSection = Section(id: sectionId, model: "", controller: createConsecutiveSectionController)
+        let secondSection = Section(id: sectionId, model: "", controller: createConsecutiveSectionController)
+
+        let adapter = ListCollectionViewAdapter(
+            collectionView: collectionView,
+            sections: [initialSection],
+            errorHandler: MockErrorHandler()
         )
         adapter.sections = [firstSection, secondSection]
         XCTAssertEqual(adapter.sections.count, 1)


### PR DESCRIPTION
## Summary
This PR fixes that duplicate section ids were not filtered properly.

## Context
The previous logic was filtering out duplicates only when setting the backing array of sections (which occurs inside the update to the `UICollectionView`). However, we have to filter them at a much earlier time, even before the update to the `UICollectionView` is calculated (so they are not included). Otherwise the duplicate sections are added in the update, but the sections don't exist anymore, so every subsequent update to the `UICollectionView` fails with an inconsistency exception.