### PR TITLE
Fix `NSInternalInconsistencyException` when `reloadData` occurs

### DIFF
--- a/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Numbers/NumbersViewModel.swift
+++ b/Example/VanillaSwiftExamples/Sources/VanillaSwiftExamples/Numbers/NumbersViewModel.swift
@@ -2,22 +2,36 @@ import Foundation
 
 internal typealias NumbersViewModelType = NumbersViewModelInputs & NumbersViewModelOutputs
 
-internal protocol NumbersViewModelInputs { }
+internal protocol NumbersViewModelInputs {
+    mutating func collapsePressed()
+}
 
 internal protocol NumbersViewModelOutputs {
     var title: String { get }
     var sections: [NumbersSectionViewModelType] { get }
+    var collapseButtonTitle: String { get }
 }
 
 internal struct NumbersViewModel: NumbersViewModelType {
     internal let title = "Numbers"
-    internal let sections: [NumbersSectionViewModelType]
+    private let allSections: [NumbersSectionViewModelType]
+    private var isCollapsed = false
+    internal var sections: [NumbersSectionViewModelType] {
+        isCollapsed ? allSections.dropLast() : allSections
+    }
+    internal var collapseButtonTitle: String {
+        isCollapsed ? "Uncollapse" : "Collapse"
+    }
 
     internal init(navigation: NumbersSectionNavigation) {
-        sections = [
+        allSections = [
             NumbersSectionViewModel(numbers: Array(0...1), navigation: navigation),
             NumbersSectionViewModel(numbers: Array(10...19), navigation: navigation),
             NumbersSectionViewModel(numbers: Array(20...24), navigation: navigation)
         ]
+    }
+
+    internal mutating func collapsePressed() {
+        isCollapsed.toggle()
     }
 }

--- a/SectionKit/Sources/Utility/UICollectionView+Apply.swift
+++ b/SectionKit/Sources/Utility/UICollectionView+Apply.swift
@@ -80,12 +80,13 @@ extension UICollectionView {
         }
 
         for batchOperation in update.batchOperations {
+            if update.shouldReload(batchOperation) {
+                update.setData(batchOperation.data)
+                reloadData()
+                continue
+            }
             performBatchUpdates({
                 update.setData(batchOperation.data)
-
-                if update.shouldReload(batchOperation) {
-                    return reloadData()
-                }
 
                 let deletes = batchOperation.deletes
                 if deletes.isNotEmpty {

--- a/SectionKit/Sources/Utility/UICollectionView+Apply.swift
+++ b/SectionKit/Sources/Utility/UICollectionView+Apply.swift
@@ -83,6 +83,7 @@ extension UICollectionView {
             if update.shouldReload(batchOperation) {
                 update.setData(batchOperation.data)
                 reloadData()
+                batchOperation.completion?(false)
                 continue
             }
             performBatchUpdates({

--- a/SectionKit/Tests/Utility/UICollectionViewApplyTests.swift
+++ b/SectionKit/Tests/Utility/UICollectionViewApplyTests.swift
@@ -361,18 +361,13 @@ internal final class UICollectionViewApplyTests: XCTestCase {
     }
 
     internal func testUpdateWithWindowWithSingleBatchOperationWithAlwaysReload() {
-        let performBatchUpdatesExpectation = expectation(description: "Should invoke performBatchUpdates")
         let setDataExpectation = expectation(description: "Should invoke setData")
         let reloadDataExpectation = expectation(description: "Should invoke reloadData")
         let completionExpectation = expectation(description: "Should invoke completion of batch operation")
 
         let collectionView = MockCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collectionView._performBatchUpdates = { updates, completion in
-            performBatchUpdatesExpectation.fulfill()
-            XCTAssertNotNil(updates)
-            updates?()
-            XCTAssertNotNil(completion)
-            completion?(true)
+            XCTFail("performBatchUpdates should not be called")
         }
         collectionView._reloadData = reloadDataExpectation.fulfill
 
@@ -403,7 +398,6 @@ internal final class UICollectionViewApplyTests: XCTestCase {
 
         wait(
             for: [
-                performBatchUpdatesExpectation,
                 setDataExpectation,
                 reloadDataExpectation,
                 completionExpectation


### PR DESCRIPTION
By default, `reloadData` may be invoked by the adapter to reload the list of sections:
- `FoundationDiffingListCollectionViewAdapter` / `DiffingListCollectionViewAdapter`: when there are more than 100 changes in a given batch operation
- `ListCollectionViewAdapter`: always

However, calling `reloadData` inside the call to `performBatchUpdates` leads to a crash and instead this call needs to be outside. I've modified the vanilla Swift `Numbers` example so it has a right bar button to toggle this edge case (if you revert 54fdcbd pressing the bar button triggers the crash).

The other overload of `apply` (for applying updates to individual sections) doesn't need to be changed as `reloadSections` doesn't seem to be affected.