### PR TITLE
Add MainActor & Sendable annotation to relevant types

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Unit Tests
-    runs-on: macOS-latest
+    runs-on: macOS-12
     if: github.event.pull_request.draft == false
     env:
       LC_ALL: en_US.UTF-8

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   build:
     name: Unit Tests
-    runs-on: macOS-11.0
+    runs-on: macOS-latest
     if: github.event.pull_request.draft == false
     env:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
-      DEVELOPER_DIR: '/Applications/Xcode_12.5.app/Contents/Developer'
+      DEVELOPER_DIR: '/Applications/Xcode_14.0.1.app/Contents/Developer'
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/DiffingSectionKit/Sources/DiffingListCollectionViewAdapter.swift
+++ b/DiffingSectionKit/Sources/DiffingListCollectionViewAdapter.swift
@@ -7,6 +7,7 @@ import SectionKit
  for the difference to the current value and separate inserts/deletes/moves will be performed
  to update the `UICollectionView`.
  */
+@MainActor
 open class DiffingListCollectionViewAdapter: ListCollectionViewAdapter {
     override open func calculateUpdate(
         from oldData: [Section],

--- a/DiffingSectionKit/Sources/DiffingListSectionController.swift
+++ b/DiffingSectionKit/Sources/DiffingListSectionController.swift
@@ -8,6 +8,7 @@ import SectionKit
  This `SectionController` is typically used when there are multiple semantically similar items
  of a model to be displayed and the list of items may dynamically change.
  */
+@MainActor
 open class DiffingListSectionController<Model, Item: Differentiable>: ListSectionController<Model, Item> {
     override open func calculateUpdate(
         from oldData: [Item],

--- a/DiffingSectionKit/Sources/ManualDiffingListSectionController.swift
+++ b/DiffingSectionKit/Sources/ManualDiffingListSectionController.swift
@@ -11,6 +11,7 @@ import SectionKit
  - Note: Compared to `DiffingListSectionController` this doesn't have a `Differentiable` constraint on the generic
  `Item` type, instead it requires closures to get diffing information for an item.
  */
+@MainActor
 open class ManualDiffingListSectionController<
     Model,
     Item

--- a/DiffingSectionKit/Sources/ManualDiffingListSectionController.swift
+++ b/DiffingSectionKit/Sources/ManualDiffingListSectionController.swift
@@ -16,8 +16,8 @@ open class ManualDiffingListSectionController<
     Model,
     Item
 >: ListSectionController<Model, Item> {
-    private let itemId: (Item) -> AnyHashable
-    private let itemContentIsEqual: (Item, Item) -> Bool
+    private let itemId: @MainActor (Item) -> AnyHashable
+    private let itemContentIsEqual: @MainActor (Item, Item) -> Bool
 
     /**
      Initialise an instance of `ManualDiffingListSectionController`.
@@ -30,8 +30,8 @@ open class ManualDiffingListSectionController<
      */
     public init<ItemId: Hashable>(
         model: Model,
-        itemId: @escaping (Item) -> ItemId,
-        itemContentIsEqual: @escaping (Item, Item) -> Bool
+        itemId: @escaping @MainActor (Item) -> ItemId,
+        itemContentIsEqual: @escaping @MainActor (Item, Item) -> Bool
     ) {
         self.itemId = { itemId($0) }
         self.itemContentIsEqual = itemContentIsEqual
@@ -63,7 +63,7 @@ extension ManualDiffingListSectionController where Item: Equatable {
 
      - Parameter itemId: A closure that returns the identifier for a given item.
      */
-    public convenience init<ItemId: Hashable>(model: Model, itemId: @escaping (Item) -> ItemId) {
+    public convenience init<ItemId: Hashable>(model: Model, itemId: @escaping @MainActor (Item) -> ItemId) {
         self.init(model: model, itemId: itemId, itemContentIsEqual: ==)
     }
 }
@@ -77,7 +77,7 @@ extension ManualDiffingListSectionController where Item: Identifiable {
 
      - Parameter itemContentIsEqual: A closure that checks two items for equality.
      */
-    public convenience init(model: Model, itemContentIsEqual: @escaping (Item, Item) -> Bool) {
+    public convenience init(model: Model, itemContentIsEqual: @escaping @MainActor (Item, Item) -> Bool) {
         self.init(model: model, itemId: \.id, itemContentIsEqual: itemContentIsEqual)
     }
 }
@@ -102,8 +102,8 @@ extension ManualDiffingListSectionController where Item: Identifiable & Equatabl
     @_disfavoredOverload
     public convenience init(
         model: Model,
-        itemId: @escaping (Item) -> Item.ID = { $0.id },
-        itemContentIsEqual: @escaping (Item, Item) -> Bool = { $0 == $1 }
+        itemId: @escaping @MainActor (Item) -> Item.ID = { $0.id },
+        itemContentIsEqual: @escaping @MainActor (Item, Item) -> Bool = { $0 == $1 }
     ) {
         self.init(model: model, itemId: itemId, itemContentIsEqual: itemContentIsEqual)
     }

--- a/DiffingSectionKit/Sources/Utility/DifferentiableBox.swift
+++ b/DiffingSectionKit/Sources/Utility/DifferentiableBox.swift
@@ -1,16 +1,17 @@
 import DifferenceKit
 import Foundation
 
+@MainActor
 public struct DifferentiableBox<Value, Id: Hashable> {
     public let value: Value
 
     @usableFromInline
-    internal let id: (Value) -> Id
+    internal let id: @MainActor (Value) -> Id
 
     @usableFromInline
-    internal let isContentEqual: (Value, Value) -> Bool
+    internal let isContentEqual: @MainActor (Value, Value) -> Bool
 
-    public init(value: Value, id: @escaping (Value) -> Id, isContentEqual: @escaping (Value, Value) -> Bool) {
+    public init(value: Value, id: @escaping @MainActor (Value) -> Id, isContentEqual: @escaping @MainActor (Value, Value) -> Bool) {
         self.value = value
         self.id = id
         self.isContentEqual = isContentEqual

--- a/DiffingSectionKit/Tests/DiffingListCollectionViewAdapterTests.swift
+++ b/DiffingSectionKit/Tests/DiffingListCollectionViewAdapterTests.swift
@@ -2,6 +2,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class DiffingListCollectionViewAdapterTests: XCTestCase {
     private struct MockSectionModel: Equatable {
         let sectionId: AnyHashable = UUID()

--- a/Example/Examples/Package.swift
+++ b/Example/Examples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/Example/ReactiveSwiftExamples/Package.swift
+++ b/Example/ReactiveSwiftExamples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/Example/Utilities/Package.swift
+++ b/Example/Utilities/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/Example/VanillaSwiftExamples/Package.swift
+++ b/Example/VanillaSwiftExamples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/SectionKit/Sources/CollectionViewAdapter/CollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/CollectionViewAdapter.swift
@@ -4,6 +4,7 @@ import UIKit
  The root object for a given `UICollectionView` that forwards datasource and delegate
  methods to the corresponding `SectionController`.
  */
+@MainActor
 public protocol CollectionViewAdapter: AnyObject {
     /// An object providing contextual information.
     var context: CollectionViewContext { get }

--- a/SectionKit/Sources/CollectionViewAdapter/CollectionViewContext/CollectionViewContext.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/CollectionViewContext/CollectionViewContext.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// A context which provides contextual information for a `SectionController`.
+@MainActor
 public protocol CollectionViewContext: AnyObject {
     /// The `UIViewController` which contains the `collectionView`.
     var viewController: UIViewController? { get }

--- a/SectionKit/Sources/CollectionViewAdapter/CollectionViewContext/MainCollectionViewContext.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/CollectionViewContext/MainCollectionViewContext.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// The main context which applies changes to the `UICollectionView` directly
+@MainActor
 open class MainCollectionViewContext: CollectionViewContext {
     // MARK: - Properties
 

--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/FoundationDiffingListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/FoundationDiffingListCollectionViewAdapter.swift
@@ -5,6 +5,7 @@ import Foundation
  for the difference to the current value and separate inserts/deletes/moves will be performed accordingly.
  */
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@MainActor
 open class FoundationDiffingListCollectionViewAdapter: ListCollectionViewAdapter {
     override open func calculateUpdate(
         from oldData: [Section],

--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter.swift
@@ -7,6 +7,7 @@ import UIKit
  `reloadData()` on the underlying `UICollectionView`. If animated updates should occur, please
  override `calculateUpdate(from:to:)`.
  */
+@MainActor
 open class ListCollectionViewAdapter: NSObject, CollectionViewAdapter {
     /**
      Initialise an instance of `ListCollectionAdapter` to use it as the datasource and

--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapterDataSource.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapterDataSource.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// A datasource which provides a list of sections for a `CollectionViewAdapter`.
+@MainActor
 public protocol ListCollectionViewAdapterDataSource: AnyObject {
     /**
      Queries the list of sections in the `UICollectionView`.

--- a/SectionKit/Sources/CollectionViewAdapter/Section.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Section.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a section in the `UICollectionView`.
 @MainActor
-public class Section {
+public final class Section {
     /// An identifier that uniquely identifies this section.
     public let id: AnyHashable
 

--- a/SectionKit/Sources/CollectionViewAdapter/Section.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Section.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Represents a section in the `UICollectionView`.
+@MainActor
 public class Section {
     /// An identifier that uniquely identifies this section.
     public let id: AnyHashable
@@ -8,7 +9,7 @@ public class Section {
     /// The model of the section.
     public let model: Any
 
-    private let controllerAccessor: () -> SectionController
+    private let controllerAccessor: @MainActor () -> SectionController
 
     /// A `SectionController` for this section.
     public internal(set) lazy var controller: SectionController = controllerAccessor()
@@ -25,7 +26,7 @@ public class Section {
     public init(
         id: AnyHashable,
         model: Any,
-        controller: @escaping () -> SectionController
+        controller: @escaping @MainActor () -> SectionController
     ) {
         self.id = id
         self.model = model
@@ -46,7 +47,7 @@ extension Section {
     public convenience init(
         id: AnyHashable,
         model: Any,
-        controller: @autoclosure @escaping () -> SectionController
+        controller: @autoclosure @escaping @MainActor () -> SectionController
     ) {
         self.init(id: id, model: model, controller: controller)
     }

--- a/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter.swift
@@ -3,6 +3,7 @@ import UIKit
 /**
  A `CollectionViewAdapter` that contains a single section.
  */
+@MainActor
 open class SingleSectionCollectionViewAdapter: NSObject, CollectionViewAdapter {
     /**
      Initialise an instance of `SingleSectionCollectionViewAdapter` to use it as the datasource and

--- a/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapterDataSource.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapterDataSource.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// A datasource which provides a single section for a `CollectionViewAdapter`.
+@MainActor
 public protocol SingleSectionCollectionViewAdapterDataSource: AnyObject {
     /**
      Queries the single section in the `UICollectionView`.

--- a/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewBatchOperation.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewBatchOperation.swift
@@ -59,8 +59,6 @@ public struct CollectionViewBatchOperation<CollectionViewData> {
     }
 }
 
-extension CollectionViewBatchOperation: Sendable where CollectionViewData: Sendable { }
-
 extension CollectionViewBatchOperation {
     /// The count of changes in this batch operation.
     @inlinable

--- a/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewBatchOperation.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewBatchOperation.swift
@@ -59,6 +59,8 @@ public struct CollectionViewBatchOperation<CollectionViewData> {
     }
 }
 
+extension CollectionViewBatchOperation: Sendable where CollectionViewData: Sendable { }
+
 extension CollectionViewBatchOperation {
     /// The count of changes in this batch operation.
     @inlinable

--- a/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewBatchOperation.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewBatchOperation.swift
@@ -23,7 +23,7 @@ public struct CollectionViewBatchOperation<CollectionViewData> {
      The parameter may be `true` if all of the related animations completed successfully
      or `false` if they were interrupted.
      */
-    public let completion: ((Bool) -> Void)?
+    public let completion: (@MainActor (Bool) -> Void)?
 
     /**
      Initialise an instance of `CollectionViewBatchOperation`.
@@ -48,7 +48,7 @@ public struct CollectionViewBatchOperation<CollectionViewData> {
         inserts: Set<Int> = [],
         moves: Set<Move> = [],
         reloads: Set<Int> = [],
-        completion: ((Bool) -> Void)? = nil
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         self.data = data
         self.deletes = deletes

--- a/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewContext+CollectionViewUpdate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewContext+CollectionViewUpdate.swift
@@ -33,9 +33,9 @@ extension CollectionViewContext {
         inserts: Set<Int> = [],
         moves: Set<Move> = [],
         reloads: Set<Int> = [],
-        setData: @escaping (CollectionViewData) -> Void,
-        shouldReload: @escaping (CollectionViewBatchOperation<CollectionViewData>) -> Bool = { _ in false },
-        completion: ((Bool) -> Void)? = nil
+        setData: @escaping @MainActor (CollectionViewData) -> Void,
+        shouldReload: @escaping @MainActor (CollectionViewBatchOperation<CollectionViewData>) -> Bool = { _ in false },
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         let update = CollectionViewUpdate(
             data: data,
@@ -66,8 +66,8 @@ extension CollectionViewContext {
     @inlinable
     public func perform<CollectionViewData>(
         batchOperations: [CollectionViewBatchOperation<CollectionViewData>],
-        setData: @escaping (CollectionViewData) -> Void,
-        shouldReload: @escaping (CollectionViewBatchOperation<CollectionViewData>) -> Bool = { _ in false }
+        setData: @escaping @MainActor (CollectionViewData) -> Void,
+        shouldReload: @escaping @MainActor (CollectionViewBatchOperation<CollectionViewData>) -> Bool = { _ in false }
     ) {
         let update = CollectionViewUpdate(
             batchOperations: batchOperations,
@@ -92,8 +92,8 @@ extension CollectionViewContext {
     @inlinable
     public func reloadData<CollectionViewData>(
         data: CollectionViewData,
-        setData: @escaping (CollectionViewData) -> Void,
-        completion: ((Bool) -> Void)? = nil
+        setData: @escaping @MainActor (CollectionViewData) -> Void,
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         let update = CollectionViewUpdate(
             data: data,

--- a/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewUpdate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewUpdate.swift
@@ -8,7 +8,7 @@ public struct CollectionViewUpdate<CollectionViewData> {
     public let batchOperations: [BatchOperation]
 
     /// A handler that gets executed inside a batch operation to set the backing data of the current batch of updates.
-    public let setData: (CollectionViewData) -> Void
+    public let setData: @MainActor (CollectionViewData) -> Void
 
     /**
      A predicate that determines if instead of applying the given batch operation
@@ -17,7 +17,7 @@ public struct CollectionViewUpdate<CollectionViewData> {
      - Note: For performance reasons it is recommended to perform a reload instead of separate inserts/deletes,
      if more than `100` changes are applied in a single batch operation.
      */
-    public let shouldReload: (CollectionViewBatchOperation<CollectionViewData>) -> Bool
+    public let shouldReload: @MainActor (CollectionViewBatchOperation<CollectionViewData>) -> Bool
 
     /**
      Initialise an instance of `CollectionViewUpdate`.
@@ -34,8 +34,8 @@ public struct CollectionViewUpdate<CollectionViewData> {
      */
     public init(
         batchOperations: [BatchOperation],
-        setData: @escaping (CollectionViewData) -> Void,
-        shouldReload: @escaping (BatchOperation) -> Bool = { _ in false }
+        setData: @escaping @MainActor (CollectionViewData) -> Void,
+        shouldReload: @escaping @MainActor (BatchOperation) -> Bool = { _ in false }
     ) {
         self.batchOperations = batchOperations
         self.setData = setData
@@ -73,9 +73,9 @@ public struct CollectionViewUpdate<CollectionViewData> {
         inserts: Set<Int> = [],
         moves: Set<Move> = [],
         reloads: Set<Int> = [],
-        setData: @escaping (CollectionViewData) -> Void,
-        shouldReload: @escaping (BatchOperation) -> Bool = { _ in false },
-        completion: ((Bool) -> Void)? = nil
+        setData: @escaping @MainActor (CollectionViewData) -> Void,
+        shouldReload: @escaping @MainActor (BatchOperation) -> Bool = { _ in false },
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         let batchOperation = BatchOperation(
             data: data,
@@ -106,8 +106,8 @@ public struct CollectionViewUpdate<CollectionViewData> {
      */
     public init(
         data: CollectionViewData,
-        setData: @escaping (CollectionViewData) -> Void,
-        completion: ((Bool) -> Void)? = nil
+        setData: @escaping @MainActor (CollectionViewData) -> Void,
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         self.init(
             data: data,

--- a/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewUpdate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewUpdate.swift
@@ -117,5 +117,3 @@ public struct CollectionViewUpdate<CollectionViewData> {
         )
     }
 }
-
-extension CollectionViewUpdate: Sendable where CollectionViewData: Sendable { }

--- a/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewUpdate.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/Update/CollectionViewUpdate.swift
@@ -117,3 +117,5 @@ public struct CollectionViewUpdate<CollectionViewData> {
         )
     }
 }
+
+extension CollectionViewUpdate: Sendable where CollectionViewData: Sendable { }

--- a/SectionKit/Sources/SectionController/Generic/BaseSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/BaseSectionController.swift
@@ -5,6 +5,7 @@ import UIKit
  
  Every declaration is marked `open` and can be overridden.
  */
+@MainActor
 open class BaseSectionController: SectionController,
                                   SectionDataSource,
                                   SectionDataSourcePrefetchingDelegate,

--- a/SectionKit/Sources/SectionController/Generic/FoundationDiffingListSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/FoundationDiffingListSectionController.swift
@@ -7,6 +7,7 @@ import Foundation
  of a model to be displayed and the list of items may dynamically change.
  */
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@MainActor
 open class FoundationDiffingListSectionController<
     Model,
     Item: Hashable

--- a/SectionKit/Sources/SectionController/Generic/ListSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/ListSectionController.swift
@@ -7,6 +7,7 @@ import UIKit
  This `SectionController` is typically used when there are multiple semantically similar items
  of a model to be displayed and the list of items (almost) never changes or should not perform animated updates.
  */
+@MainActor
 open class ListSectionController<Model, Item>: BaseSectionController {
     /**
      Initialise an instance of `ListSectionController`.

--- a/SectionKit/Sources/SectionController/Generic/SingleItemSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/SingleItemSectionController.swift
@@ -10,14 +10,14 @@ import UIKit
  */
 @MainActor
 open class SingleItemSectionController<Model, Item>: BaseSectionController {
-    private let areItemsEqual: (Item, Item) -> Bool
+    private let areItemsEqual: @MainActor (Item, Item) -> Bool
 
     /**
      Initialise an instance of `SingleItemSectionController`.
 
      - Parameter model: The model of this `SectionController`.
      */
-    public init(model: Model, areItemsEqual: @escaping (Item, Item) -> Bool) {
+    public init(model: Model, areItemsEqual: @escaping @MainActor (Item, Item) -> Bool) {
         self.model = model
         self.areItemsEqual = areItemsEqual
         super.init()

--- a/SectionKit/Sources/SectionController/Generic/SingleItemSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/SingleItemSectionController.swift
@@ -8,6 +8,7 @@ import UIKit
 
  - Warning: If `numberOfItems` is overridden, `calculateUpdate(from:to:)` needs to be overridden as well.
  */
+@MainActor
 open class SingleItemSectionController<Model, Item>: BaseSectionController {
     private let areItemsEqual: (Item, Item) -> Bool
 

--- a/SectionKit/Sources/SectionController/Generic/SingleModelSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/SingleModelSectionController.swift
@@ -8,6 +8,7 @@ import UIKit
  a single model. If however all items are the semantically similar and one could derive an array of models,
  it is recommended to use `ListSectionController` instead.
  */
+@MainActor
 open class SingleModelSectionController<Model>: BaseSectionController {
     /**
      Initialise an instance of `SingleModelSectionController`.

--- a/SectionKit/Sources/SectionController/SectionController.swift
+++ b/SectionKit/Sources/SectionController/SectionController.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// A controller for a section in a `UICollectionView`.
+@MainActor
 public protocol SectionController: AnyObject {
     /// A context which provides contextual information for a `SectionController`.
     var context: CollectionViewContext? { get set }

--- a/SectionKit/Sources/SectionController/SectionDataSource.swift
+++ b/SectionKit/Sources/SectionController/SectionDataSource.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// The datasource of a section
+@MainActor
 public protocol SectionDataSource: AnyObject {
     /**
      Get the number of items in this section.

--- a/SectionKit/Sources/SectionController/SectionDataSourcePrefetchingDelegate.swift
+++ b/SectionKit/Sources/SectionController/SectionDataSourcePrefetchingDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 
 /// The delegate for datasource prefetching.
 @available(iOS 10.0, *)
+@MainActor
 public protocol SectionDataSourcePrefetchingDelegate: AnyObject {
     /**
      Tells the delegate to start prefetching items at the specified indexPaths.

--- a/SectionKit/Sources/SectionController/SectionDelegate.swift
+++ b/SectionKit/Sources/SectionController/SectionDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// The delegate of a section
+@MainActor
 public protocol SectionDelegate: AnyObject {
     // MARK: - Highlight
 

--- a/SectionKit/Sources/SectionController/SectionDragDelegate.swift
+++ b/SectionKit/Sources/SectionController/SectionDragDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 
 /// The drag delegate of a section
 @available(iOS 11.0, *)
+@MainActor
 public protocol SectionDragDelegate: AnyObject {
     /**
      Returns the initial list of items to drag.

--- a/SectionKit/Sources/SectionController/SectionDropDelegate.swift
+++ b/SectionKit/Sources/SectionController/SectionDropDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 
 /// The drop delegate of a section
 @available(iOS 11.0, *)
+@MainActor
 public protocol SectionDropDelegate: AnyObject {
     /**
      Determines if the section allows drops from the given `UIDropSession`.

--- a/SectionKit/Sources/SectionController/SectionFlowDelegate.swift
+++ b/SectionKit/Sources/SectionController/SectionFlowDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// The delegate for the `UICollectionViewFlowLayout` of a section.
+@MainActor
 public protocol SectionFlowDelegate: AnyObject {
     /**
      Returns the size for the item at the given index path.

--- a/SectionKit/Sources/SectionController/SectionIndexPath.swift
+++ b/SectionKit/Sources/SectionController/SectionIndexPath.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A struct containing the internal and external index of an item.
-public struct SectionIndexPath: Hashable {
+public struct SectionIndexPath: Hashable, Sendable {
     /// The index path of the item in the `UICollectionView`.
     public let indexInCollectionView: IndexPath
 

--- a/SectionKit/Sources/SectionController/Update/CollectionViewContext+CollectionViewSectionUpdate.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewContext+CollectionViewSectionUpdate.swift
@@ -36,9 +36,9 @@ extension CollectionViewContext {
         inserts: Set<Int> = [],
         moves: Set<Move> = [],
         reloads: Set<Int> = [],
-        setData: @escaping (SectionData) -> Void,
-        shouldReload: @escaping (CollectionViewSectionBatchOperation<SectionData>) -> Bool = { _ in false },
-        completion: ((Bool) -> Void)? = nil
+        setData: @escaping @MainActor (SectionData) -> Void,
+        shouldReload: @escaping @MainActor (CollectionViewSectionBatchOperation<SectionData>) -> Bool = { _ in false },
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         let update = CollectionViewSectionUpdate(
             controller: controller,
@@ -73,8 +73,8 @@ extension CollectionViewContext {
     public func perform<SectionData>(
         controller: SectionController,
         batchOperations: [CollectionViewSectionBatchOperation<SectionData>],
-        setData: @escaping (SectionData) -> Void,
-        shouldReload: @escaping (CollectionViewSectionBatchOperation<SectionData>) -> Bool = { _ in false }
+        setData: @escaping @MainActor (SectionData) -> Void,
+        shouldReload: @escaping @MainActor (CollectionViewSectionBatchOperation<SectionData>) -> Bool = { _ in false }
     ) {
         let update = CollectionViewSectionUpdate(
             controller: controller,
@@ -104,7 +104,7 @@ extension CollectionViewContext {
         controller: SectionController,
         data: SectionData,
         setData: @escaping (SectionData) -> Void,
-        completion: ((Bool) -> Void)? = nil
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         let update = CollectionViewSectionUpdate(
             controller: controller,

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionBatchOperation.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionBatchOperation.swift
@@ -23,7 +23,7 @@ public struct CollectionViewSectionBatchOperation<SectionData> {
      The parameter may be `true` if all of the related animations completed successfully
      or `false` if they were interrupted.
      */
-    public let completion: ((Bool) -> Void)?
+    public let completion: (@MainActor (Bool) -> Void)?
 
     /**
      Initialise an instance of `CollectionViewSectionBatchOperation`.
@@ -48,7 +48,7 @@ public struct CollectionViewSectionBatchOperation<SectionData> {
         inserts: Set<Int> = [],
         moves: Set<Move> = [],
         reloads: Set<Int> = [],
-        completion: ((Bool) -> Void)? = nil
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         self.data = data
         self.deletes = deletes

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionBatchOperation.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionBatchOperation.swift
@@ -59,6 +59,8 @@ public struct CollectionViewSectionBatchOperation<SectionData> {
     }
 }
 
+extension CollectionViewSectionBatchOperation: Sendable where SectionData: Sendable { }
+
 extension CollectionViewSectionBatchOperation {
     /// The count of changes in this batch operation.
     @inlinable

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionBatchOperation.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionBatchOperation.swift
@@ -59,8 +59,6 @@ public struct CollectionViewSectionBatchOperation<SectionData> {
     }
 }
 
-extension CollectionViewSectionBatchOperation: Sendable where SectionData: Sendable { }
-
 extension CollectionViewSectionBatchOperation {
     /// The count of changes in this batch operation.
     @inlinable

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
@@ -11,7 +11,7 @@ public struct CollectionViewSectionUpdate<SectionData> {
     public let batchOperations: [BatchOperation]
 
     /// A handler that gets executed inside a batch operation to set the backing data of the current batch of updates.
-    public let setData: (SectionData) -> Void
+    public let setData: @MainActor (SectionData) -> Void
 
     /**
      A predicate that determines if instead of applying the given batch operation
@@ -20,7 +20,7 @@ public struct CollectionViewSectionUpdate<SectionData> {
      - Note: For performance reasons it is recommended to perform a reload instead of separate inserts/deletes,
      if more than `100` changes are applied in a single batch operation.
      */
-    public let shouldReload: (CollectionViewSectionBatchOperation<SectionData>) -> Bool
+    public let shouldReload: @MainActor (CollectionViewSectionBatchOperation<SectionData>) -> Bool
 
     /**
      Initialise an instance of `CollectionViewSectionUpdate`.
@@ -40,8 +40,8 @@ public struct CollectionViewSectionUpdate<SectionData> {
     public init(
         controller: SectionController,
         batchOperations: [BatchOperation],
-        setData: @escaping (SectionData) -> Void,
-        shouldReload: @escaping (BatchOperation) -> Bool = { _ in false }
+        setData: @escaping @MainActor (SectionData) -> Void,
+        shouldReload: @escaping @MainActor (BatchOperation) -> Bool = { _ in false }
     ) {
         self.controller = controller
         self.batchOperations = batchOperations
@@ -83,9 +83,9 @@ public struct CollectionViewSectionUpdate<SectionData> {
         inserts: Set<Int> = [],
         moves: Set<Move> = [],
         reloads: Set<Int> = [],
-        setData: @escaping (SectionData) -> Void,
-        shouldReload: @escaping (BatchOperation) -> Bool = { _ in false },
-        completion: ((Bool) -> Void)? = nil
+        setData: @escaping @MainActor (SectionData) -> Void,
+        shouldReload: @escaping @MainActor (BatchOperation) -> Bool = { _ in false },
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         let batchOperation = BatchOperation(
             data: data,
@@ -120,8 +120,8 @@ public struct CollectionViewSectionUpdate<SectionData> {
     public init(
         controller: SectionController,
         data: SectionData,
-        setData: @escaping (SectionData) -> Void,
-        completion: ((Bool) -> Void)? = nil
+        setData: @escaping @MainActor (SectionData) -> Void,
+        completion: (@MainActor (Bool) -> Void)? = nil
     ) {
         self.init(
             controller: controller,

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
@@ -132,3 +132,5 @@ public struct CollectionViewSectionUpdate<SectionData> {
         )
     }
 }
+
+extension CollectionViewSectionUpdate: Sendable where SectionData: Sendable { }

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
@@ -132,5 +132,3 @@ public struct CollectionViewSectionUpdate<SectionData> {
         )
     }
 }
-
-extension CollectionViewSectionUpdate: Sendable where SectionData: Sendable { }

--- a/SectionKit/Sources/Utility/Move.swift
+++ b/SectionKit/Sources/Utility/Move.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents a move from an index to another index.
-public struct Move: Hashable {
+public struct Move: Hashable, Sendable {
     /// The index before the move.
     public let at: Int
 

--- a/SectionKit/Tests/CollectionViewAdapter/CollectionViewContext/CollectionViewContextExtensionsTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/CollectionViewContext/CollectionViewContextExtensionsTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class CollectionViewContextExtensionsTests: XCTestCase {
     // MARK: - dequeueReusableCell
 

--- a/SectionKit/Tests/CollectionViewAdapter/CollectionViewContext/CollectionViewContextSizeTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/CollectionViewContext/CollectionViewContextSizeTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class CollectionViewContextSizeTests: XCTestCase {
     internal func testContainerSize() {
         let rect = CGRect(x: 1, y: 2, width: 4, height: 8)

--- a/SectionKit/Tests/CollectionViewAdapter/CollectionViewContext/MainCollectionViewContextTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/CollectionViewContext/MainCollectionViewContextTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class MainCollectionViewContextTests: XCTestCase {
     internal func testAdapterIsWeakReferenced() {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())

--- a/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/ListCollectionViewAdapterTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class ListCollectionViewAdapterTests: XCTestCase {
     // MARK: - Init with datasource
 

--- a/SectionKit/Tests/CollectionViewAdapter/SingleSectionCollectionViewAdapterTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/SingleSectionCollectionViewAdapterTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class SingleSectionCollectionViewAdapterTests: XCTestCase {
     // MARK: - Init with datasource
 

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSource/BaseCollectionViewAdapterUICollectionViewDataSourceTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSource/BaseCollectionViewAdapterUICollectionViewDataSourceTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal class BaseCollectionViewAdapterUICollectionViewDataSourceTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -16,9 +17,9 @@ internal class BaseCollectionViewAdapterUICollectionViewDataSourceTests: XCTestC
 
     internal func createCollectionView(
         frame: CGRect = .zero,
-        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout layout: UICollectionViewLayout? = nil
     ) -> UICollectionView {
-        UICollectionView(frame: frame, collectionViewLayout: layout)
+        UICollectionView(frame: frame, collectionViewLayout: layout ?? UICollectionViewFlowLayout())
     }
 
     internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSource/ListCollectionViewAdapterUICollectionViewDataSourceTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSource/ListCollectionViewAdapterUICollectionViewDataSourceTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class ListCollectionViewAdapterUICollectionViewDataSourceTests: BaseCollectionViewAdapterUICollectionViewDataSourceTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSource/SingleSectionCollectionViewAdapterUICollectionViewDataSourceTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSource/SingleSectionCollectionViewAdapterUICollectionViewDataSourceTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class SingleSectionCollectionViewAdapterUICollectionViewDataSourceTests: BaseCollectionViewAdapterUICollectionViewDataSourceTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSourcePrefetching/BaseCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSourcePrefetching/BaseCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 10.0, *)
 internal class BaseCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests: XCTestCase {
     override func setUpWithError() throws {
@@ -17,9 +18,9 @@ internal class BaseCollectionViewAdapterUICollectionViewDataSourcePrefetchingTes
 
     internal func createCollectionView(
         frame: CGRect = .zero,
-        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout layout: UICollectionViewLayout? = nil
     ) -> UICollectionView {
-        UICollectionView(frame: frame, collectionViewLayout: layout)
+        UICollectionView(frame: frame, collectionViewLayout: layout ?? UICollectionViewFlowLayout())
     }
 
     internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSourcePrefetching/ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSourcePrefetching/ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 10.0, *)
 internal final class ListCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests: BaseCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests {
     override internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSourcePrefetching/SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDataSourcePrefetching/SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 10.0, *)
 internal final class SingleSectionCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests: BaseCollectionViewAdapterUICollectionViewDataSourcePrefetchingTests {
     override internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/BaseCollectionViewAdapterUICollectionViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/BaseCollectionViewAdapterUICollectionViewDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal class BaseCollectionViewAdapterUICollectionViewDelegateTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -16,9 +17,9 @@ internal class BaseCollectionViewAdapterUICollectionViewDelegateTests: XCTestCas
 
     internal func createCollectionView(
         frame: CGRect = .zero,
-        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout layout: UICollectionViewLayout? = nil
     ) -> UICollectionView {
-        UICollectionView(frame: frame, collectionViewLayout: layout)
+        UICollectionView(frame: frame, collectionViewLayout: layout ?? UICollectionViewFlowLayout())
     }
 
     internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/ListCollectionViewAdapterUICollectionViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/ListCollectionViewAdapterUICollectionViewDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class ListCollectionViewAdapterUICollectionViewDelegateTests: BaseCollectionViewAdapterUICollectionViewDelegateTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegate/SingleSectionCollectionViewAdapterUICollectionViewDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class SingleSectionCollectionViewAdapterUICollectionViewDelegateTests: BaseCollectionViewAdapterUICollectionViewDelegateTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegateFlowLayout/BaseCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegateFlowLayout/BaseCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal class BaseCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -16,9 +17,9 @@ internal class BaseCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests:
 
     internal func createCollectionView(
         frame: CGRect = .zero,
-        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout layout: UICollectionViewLayout? = nil
     ) -> UICollectionView {
-        UICollectionView(frame: frame, collectionViewLayout: layout)
+        UICollectionView(frame: frame, collectionViewLayout: layout ?? UICollectionViewFlowLayout())
     }
 
     internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegateFlowLayout/ListCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegateFlowLayout/ListCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class ListCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests: BaseCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegateFlowLayout/SingleSectionCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDelegateFlowLayout/SingleSectionCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class SingleSectionCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests: BaseCollectionViewAdapterUICollectionViewDelegateFlowLayoutTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDragDelegate/BaseCollectionViewAdapterUICollectionViewDragDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDragDelegate/BaseCollectionViewAdapterUICollectionViewDragDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal class BaseCollectionViewAdapterUICollectionViewDragDelegateTests: XCTestCase {
     override func setUpWithError() throws {
@@ -17,9 +18,9 @@ internal class BaseCollectionViewAdapterUICollectionViewDragDelegateTests: XCTes
 
     internal func createCollectionView(
         frame: CGRect = .zero,
-        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout layout: UICollectionViewLayout? = nil
     ) -> UICollectionView {
-        UICollectionView(frame: frame, collectionViewLayout: layout)
+        UICollectionView(frame: frame, collectionViewLayout: layout ?? UICollectionViewFlowLayout())
     }
 
     internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDragDelegate/SingleSectionCollectionViewAdapterUICollectionViewDragDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDragDelegate/SingleSectionCollectionViewAdapterUICollectionViewDragDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal final class SingleSectionCollectionViewAdapterUICollectionViewDragDelegateTests: BaseCollectionViewAdapterUICollectionViewDragDelegateTests {
     override internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDropDelegate/BaseCollectionViewAdapterUICollectionViewDropDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDropDelegate/BaseCollectionViewAdapterUICollectionViewDropDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal class BaseCollectionViewAdapterUICollectionViewDropDelegateTests: XCTestCase {
     override func setUpWithError() throws {
@@ -17,9 +18,9 @@ internal class BaseCollectionViewAdapterUICollectionViewDropDelegateTests: XCTes
 
     internal func createCollectionView(
         frame: CGRect = .zero,
-        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout layout: UICollectionViewLayout? = nil
     ) -> UICollectionView {
-        UICollectionView(frame: frame, collectionViewLayout: layout)
+        UICollectionView(frame: frame, collectionViewLayout: layout ?? UICollectionViewFlowLayout())
     }
 
     internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDropDelegate/ListCollectionViewAdapterUICollectionViewDropDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDropDelegate/ListCollectionViewAdapterUICollectionViewDropDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal final class ListCollectionViewAdapterUICollectionViewDropDelegateTests: BaseCollectionViewAdapterUICollectionViewDropDelegateTests {
     override internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDropDelegate/SingleSectionCollectionViewAdapterUICollectionViewDropDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UICollectionViewDropDelegate/SingleSectionCollectionViewAdapterUICollectionViewDropDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal final class SingleSectionCollectionViewAdapterUICollectionViewDropDelegateTests: BaseCollectionViewAdapterUICollectionViewDropDelegateTests {
     override internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UIScrollViewDelegate/BaseCollectionViewAdapterUIScrollViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UIScrollViewDelegate/BaseCollectionViewAdapterUIScrollViewDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal class BaseCollectionViewAdapterUIScrollViewDelegateTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -16,9 +17,9 @@ internal class BaseCollectionViewAdapterUIScrollViewDelegateTests: XCTestCase {
 
     internal func createCollectionView(
         frame: CGRect = .zero,
-        collectionViewLayout layout: UICollectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout layout: UICollectionViewLayout? = nil
     ) -> UICollectionView {
-        UICollectionView(frame: frame, collectionViewLayout: layout)
+        UICollectionView(frame: frame, collectionViewLayout: layout ?? UICollectionViewFlowLayout())
     }
 
     internal func createCollectionViewAdapter(

--- a/SectionKit/Tests/CollectionViewAdapter/UIScrollViewDelegate/ListCollectionViewAdapterUIScrollViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UIScrollViewDelegate/ListCollectionViewAdapterUIScrollViewDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class ListCollectionViewAdapterUIScrollViewDelegateTests: BaseCollectionViewAdapterUIScrollViewDelegateTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/CollectionViewAdapter/UIScrollViewDelegate/SingleSectionCollectionViewAdapterUIScrollViewDelegateTests.swift
+++ b/SectionKit/Tests/CollectionViewAdapter/UIScrollViewDelegate/SingleSectionCollectionViewAdapterUIScrollViewDelegateTests.swift
@@ -2,6 +2,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 internal final class SingleSectionCollectionViewAdapterUIScrollViewDelegateTests: BaseCollectionViewAdapterUIScrollViewDelegateTests {
     override internal func createCollectionViewAdapter(
         collectionView: UICollectionView,

--- a/SectionKit/Tests/SectionController/BaseSectionControllerTests.swift
+++ b/SectionKit/Tests/SectionController/BaseSectionControllerTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class BaseSectionControllerTests: XCTestCase {
     internal func testContextIsNil() {
         let sectionController = BaseSectionController()

--- a/SectionKit/Tests/SectionController/ListSectionControllerTests.swift
+++ b/SectionKit/Tests/SectionController/ListSectionControllerTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class ListSectionControllerTests: XCTestCase {
     internal func testDidUpdateModelWithValidTypeSetsModel() {
         let sectionController = ListSectionController<String, String>(model: "1")

--- a/SectionKit/Tests/SectionController/ProtocolDefaultValuesSectionControllerTests.swift
+++ b/SectionKit/Tests/SectionController/ProtocolDefaultValuesSectionControllerTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class ProtocolDefaultValuesSectionControllerTests: XCTestCase {
     private func createSectionController() -> SectionController {
         class DefaultSectionController: SectionController {

--- a/SectionKit/Tests/SectionController/SectionDataSource/BaseSectionControllerSectionDataSourceTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDataSource/BaseSectionControllerSectionDataSourceTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class BaseSectionControllerSectionDataSourceTests: BaseSectionDataSourceTests {
     override func createSectionDataSource() throws -> SectionDataSource {
         BaseSectionController()

--- a/SectionKit/Tests/SectionController/SectionDataSource/BaseSectionDataSourceTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDataSource/BaseSectionDataSourceTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal class BaseSectionDataSourceTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/SectionKit/Tests/SectionController/SectionDataSource/ProtocolDefaultValuesSectionDataSourceTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDataSource/ProtocolDefaultValuesSectionDataSourceTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class ProtocolDefaultValuesSectionDataSourceTests: BaseSectionDataSourceTests {
     override func createSectionDataSource() throws -> SectionDataSource {
         class DefaultSectionDataSource: SectionDataSource {

--- a/SectionKit/Tests/SectionController/SectionDataSourcePrefetchingDelegate/BaseSectionControllerSectionDataSourcePrefetchingDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDataSourcePrefetchingDelegate/BaseSectionControllerSectionDataSourcePrefetchingDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 10.0, *)
 internal final class BaseSectionControllerSectionDataSourcePrefetchingDelegateTests: BaseSectionDataSourcePrefetchingDelegateTests {
     override func createSectionDataSourcePrefetchingDelegate() throws -> SectionDataSourcePrefetchingDelegate {

--- a/SectionKit/Tests/SectionController/SectionDataSourcePrefetchingDelegate/BaseSectionDataSourcePrefetchingDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDataSourcePrefetchingDelegate/BaseSectionDataSourcePrefetchingDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 10.0, *)
 internal class BaseSectionDataSourcePrefetchingDelegateTests: XCTestCase {
     override func setUpWithError() throws {

--- a/SectionKit/Tests/SectionController/SectionDataSourcePrefetchingDelegate/ProtocolDefaultValuesSectionDataSourcePrefetchingDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDataSourcePrefetchingDelegate/ProtocolDefaultValuesSectionDataSourcePrefetchingDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 10.0, *)
 internal final class ProtocolDefaultValuesSectionDataSourcePrefetchingDelegateTests: BaseSectionDataSourcePrefetchingDelegateTests {
     override func createSectionDataSourcePrefetchingDelegate() throws -> SectionDataSourcePrefetchingDelegate {

--- a/SectionKit/Tests/SectionController/SectionDelegate/BaseSectionControllerSectionDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDelegate/BaseSectionControllerSectionDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class BaseSectionControllerSectionDelegateTests: BaseSectionDelegateTests {
     override func createSectionDelegate() throws -> SectionDelegate {
         BaseSectionController()

--- a/SectionKit/Tests/SectionController/SectionDelegate/BaseSectionDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDelegate/BaseSectionDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal class BaseSectionDelegateTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/SectionKit/Tests/SectionController/SectionDelegate/ProtocolDefaultValuesSectionDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDelegate/ProtocolDefaultValuesSectionDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class ProtocolDefaultValuesSectionDelegateTests: BaseSectionDelegateTests {
     override func createSectionDelegate() throws -> SectionDelegate {
         class DefaultSectionDelegate: SectionDelegate { }

--- a/SectionKit/Tests/SectionController/SectionDragDelegate/BaseSectionControllerSectionDragDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDragDelegate/BaseSectionControllerSectionDragDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal final class BaseSectionControllerSectionDragDelegateTests: BaseSectionDragDelegateTests {
     override func createSectionDragDelegate() throws -> SectionDragDelegate {

--- a/SectionKit/Tests/SectionController/SectionDragDelegate/BaseSectionDragDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDragDelegate/BaseSectionDragDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal class BaseSectionDragDelegateTests: XCTestCase {
     override func setUpWithError() throws {

--- a/SectionKit/Tests/SectionController/SectionDropDelegate/BaseSectionControllerSectionDropDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDropDelegate/BaseSectionControllerSectionDropDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal final class BaseSectionControllerSectionDropDelegateTests: BaseSectionDropDelegateTests {
     override func createSectionDropDelegate() throws -> SectionDropDelegate {

--- a/SectionKit/Tests/SectionController/SectionDropDelegate/BaseSectionDropDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDropDelegate/BaseSectionDropDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal class BaseSectionDropDelegateTests: XCTestCase {
     override func setUpWithError() throws {

--- a/SectionKit/Tests/SectionController/SectionDropDelegate/ProtocolDefaultValuesSectionDropDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionDropDelegate/ProtocolDefaultValuesSectionDropDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 @available(iOS 11.0, *)
 internal final class ProtocolDefaultValuesSectionDropDelegateTests: BaseSectionDropDelegateTests {
     override func createSectionDropDelegate() throws -> SectionDropDelegate {

--- a/SectionKit/Tests/SectionController/SectionFlowDelegate/BaseSectionControllerSectionFlowDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionFlowDelegate/BaseSectionControllerSectionFlowDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class BaseSectionControllerSectionFlowDelegateTests: BaseSectionFlowDelegateTests {
     override func createSectionFlowDelegate() throws -> SectionFlowDelegate {
         BaseSectionController()

--- a/SectionKit/Tests/SectionController/SectionFlowDelegate/BaseSectionFlowDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionFlowDelegate/BaseSectionFlowDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal class BaseSectionFlowDelegateTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/SectionKit/Tests/SectionController/SectionFlowDelegate/ProtocolDefaultValuesSectionFlowDelegateTests.swift
+++ b/SectionKit/Tests/SectionController/SectionFlowDelegate/ProtocolDefaultValuesSectionFlowDelegateTests.swift
@@ -1,6 +1,7 @@
 import SectionKit
 import XCTest
 
+@MainActor
 internal final class ProtocolDefaultValuesSectionFlowDelegateTests: BaseSectionFlowDelegateTests {
     override func createSectionFlowDelegate() throws -> SectionFlowDelegate {
         class DefaultSectionFlowDelegate: SectionFlowDelegate { }

--- a/SectionKit/Tests/SectionController/SingleItemSectionControllerTests.swift
+++ b/SectionKit/Tests/SectionController/SingleItemSectionControllerTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class SingleItemSectionControllerTests: XCTestCase {
     internal func testDidUpdateModelWithValidTypeSetsModel() {
         let sectionController = SingleItemSectionController<String, String>(model: "1")

--- a/SectionKit/Tests/SectionController/SingleModelSectionControllerTests.swift
+++ b/SectionKit/Tests/SectionController/SingleModelSectionControllerTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class SingleModelSectionControllerTests: XCTestCase {
     internal func testDidUpdateModelWithValidTypeSetsModel() {
         let sectionController = SingleModelSectionController(model: "1")

--- a/SectionKit/Tests/Utility/UICollectionViewApplyTests.swift
+++ b/SectionKit/Tests/Utility/UICollectionViewApplyTests.swift
@@ -1,6 +1,7 @@
 @testable import SectionKit
 import XCTest
 
+@MainActor
 internal final class UICollectionViewApplyTests: XCTestCase {
     // MARK: - CollectionViewSectionUpdate
 


### PR DESCRIPTION
This PR adds the `@MainActor` annotation, and thus `MainActor` isolation, to all relevant types and closures in SectionKit and DiffingSectionKit.
This makes it possible for the compiler to statically detect, whether a function might be called from a background thread.
Since SectionKit interacts with `UICollectionView`, it is very important, that all accesses to its functions are performed from the main thread.

Theoretically, using the `MainActor` class requires iOS 13, but I've tested the annotation with a project that targets iOS 11 (the oldest iOS version that Xcode 14 supports) and it compiled without complaints (it seems the actor isolation is toolchain specific, whereas calling a function like `MainActor.run` is iOS version specific). This means, the only requirement is Swift 5.5 (which is shipped with Xcode 13.0). Thus this PR increases the `swift-tools-version` to 5.5 to fit that requirement.

Additionally, some types have been marked as `Sendable`.

**Please note**: This is potentially a source breaking change.