### PR TITLE
Fix snapshot testing dependency in example project

### DIFF
--- a/Example/ReactiveSwiftExamples/Package.swift
+++ b/Example/ReactiveSwiftExamples/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(name: "Utilities", path: "Utilities"),
         .package(name: "ReactiveCocoa", url: "https://github.com/ReactiveCocoa/ReactiveCocoa.git", from: "11.2.1"),
         .package(name: "ReactiveSwift", url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.6.0"),
-        .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.9.0")
+        .package(name: "swift-snapshot-testing", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.10.0")
     ],
     targets: [
         .target(
@@ -32,7 +32,7 @@ let package = Package(
             dependencies: [
                 "ReactiveSwiftExamples",
                 .product(name: "TestUtilities", package: "Utilities"),
-                .product(name: "SnapshotTesting", package: "SnapshotTesting")
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
             exclude: ["__Snapshots__"]
         )

--- a/Example/SectionKitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SectionKitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,12 +29,12 @@
         }
       },
       {
-        "package": "SnapshotTesting",
+        "package": "swift-snapshot-testing",
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
         "state": {
           "branch": null,
-          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
-          "version": "1.9.0"
+          "revision": "f29e2014f6230cf7d5138fc899da51c7f513d467",
+          "version": "1.10.0"
         }
       }
     ]

--- a/Example/Utilities/Package.swift
+++ b/Example/Utilities/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "SectionKit", path: "../../"),
-        .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.9.0")
+        .package(name: "swift-snapshot-testing", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.10.0")
     ],
     targets: [
         .target(name: "Utilities"),
@@ -29,7 +29,7 @@ let package = Package(
             dependencies: [
                 "Utilities",
                 "TestUtilities",
-                .product(name: "SnapshotTesting", package: "SnapshotTesting")
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
             exclude: ["__Snapshots__"]
         ),

--- a/Example/VanillaSwiftExamples/Package.swift
+++ b/Example/VanillaSwiftExamples/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(name: "SectionKit", path: "../../"),
         .package(name: "Utilities", path: "Utilities"),
-        .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.9.0")
+        .package(name: "swift-snapshot-testing", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.10.0")
     ],
     targets: [
         .target(
@@ -28,7 +28,7 @@ let package = Package(
             dependencies: [
                 "VanillaSwiftExamples",
                 .product(name: "TestUtilities", package: "Utilities"),
-                .product(name: "SnapshotTesting", package: "SnapshotTesting")
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
             exclude: ["__Snapshots__"]
         )


### PR DESCRIPTION
The dependency for creating snapshot tests has been renamed from `SnapshotTesting` to `swift-snapshot-testing`. This is a breaking change and because the major version was not increased, Xcode fails to resolve package versions because of this.