### PR TITLE
Fix Xcode 14 compiler warnings

### DIFF
--- a/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter+Convenience.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/ListCollectionViewAdapter/ListCollectionViewAdapter+Convenience.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension ListCollectionViewAdapter {
     @inlinable
-    open func controller(at indexPath: IndexPath) -> SectionController? {
+    public func controller(at indexPath: IndexPath) -> SectionController? {
         guard indexPath.isValid else {
             return nil
         }
@@ -10,7 +10,7 @@ extension ListCollectionViewAdapter {
     }
 
     @inlinable
-    open func controller(at index: Int) -> SectionController? {
+    public func controller(at index: Int) -> SectionController? {
         guard index >= 0 && index < sections.count else {
             return nil
         }
@@ -20,12 +20,12 @@ extension ListCollectionViewAdapter {
 
 extension ListCollectionViewAdapter {
     @inlinable
-    open func dataSource(at indexPath: IndexPath) -> SectionDataSource? {
+    public func dataSource(at indexPath: IndexPath) -> SectionDataSource? {
         controller(at: indexPath)?.dataSource
     }
 
     @inlinable
-    open func dataSource(at index: Int) -> SectionDataSource? {
+    public func dataSource(at index: Int) -> SectionDataSource? {
         controller(at: index)?.dataSource
     }
 }
@@ -33,36 +33,36 @@ extension ListCollectionViewAdapter {
 @available(iOS 10.0, *)
 extension ListCollectionViewAdapter {
     @inlinable
-    open func dataSourcePrefetchingDelegate(at indexPath: IndexPath) -> SectionDataSourcePrefetchingDelegate? {
+    public func dataSourcePrefetchingDelegate(at indexPath: IndexPath) -> SectionDataSourcePrefetchingDelegate? {
         controller(at: indexPath)?.dataSourcePrefetchingDelegate
     }
 
     @inlinable
-    open func dataSourcePrefetchingDelegate(at index: Int) -> SectionDataSourcePrefetchingDelegate? {
+    public func dataSourcePrefetchingDelegate(at index: Int) -> SectionDataSourcePrefetchingDelegate? {
         controller(at: index)?.dataSourcePrefetchingDelegate
     }
 }
 
 extension ListCollectionViewAdapter {
     @inlinable
-    open func delegate(at indexPath: IndexPath) -> SectionDelegate? {
+    public func delegate(at indexPath: IndexPath) -> SectionDelegate? {
         controller(at: indexPath)?.delegate
     }
 
     @inlinable
-    open func delegate(at index: Int) -> SectionDelegate? {
+    public func delegate(at index: Int) -> SectionDelegate? {
         controller(at: index)?.delegate
     }
 }
 
 extension ListCollectionViewAdapter {
     @inlinable
-    open func flowDelegate(at indexPath: IndexPath) -> SectionFlowDelegate? {
+    public func flowDelegate(at indexPath: IndexPath) -> SectionFlowDelegate? {
         controller(at: indexPath)?.flowDelegate
     }
 
     @inlinable
-    open func flowDelegate(at index: Int) -> SectionFlowDelegate? {
+    public func flowDelegate(at index: Int) -> SectionFlowDelegate? {
         controller(at: index)?.flowDelegate
     }
 }
@@ -70,12 +70,12 @@ extension ListCollectionViewAdapter {
 @available(iOS 11.0, *)
 extension ListCollectionViewAdapter {
     @inlinable
-    open func dragDelegate(at indexPath: IndexPath) -> SectionDragDelegate? {
+    public func dragDelegate(at indexPath: IndexPath) -> SectionDragDelegate? {
         controller(at: indexPath)?.dragDelegate
     }
 
     @inlinable
-    open func dragDelegate(at index: Int) -> SectionDragDelegate? {
+    public func dragDelegate(at index: Int) -> SectionDragDelegate? {
         controller(at: index)?.dragDelegate
     }
 }
@@ -83,12 +83,12 @@ extension ListCollectionViewAdapter {
 @available(iOS 11.0, *)
 extension ListCollectionViewAdapter {
     @inlinable
-    open func dropDelegate(at indexPath: IndexPath) -> SectionDropDelegate? {
+    public func dropDelegate(at indexPath: IndexPath) -> SectionDropDelegate? {
         controller(at: indexPath)?.dropDelegate
     }
 
     @inlinable
-    open func dropDelegate(at index: Int) -> SectionDropDelegate? {
+    public func dropDelegate(at index: Int) -> SectionDropDelegate? {
         controller(at: index)?.dropDelegate
     }
 }

--- a/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter+Convenience.swift
+++ b/SectionKit/Sources/CollectionViewAdapter/SingleSectionCollectionViewAdapter/SingleSectionCollectionViewAdapter+Convenience.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension SingleSectionCollectionViewAdapter {
     @inlinable
-    open func controller(at indexPath: IndexPath) -> SectionController? {
+    public func controller(at indexPath: IndexPath) -> SectionController? {
         guard indexPath.isValid else {
             return nil
         }
@@ -10,7 +10,7 @@ extension SingleSectionCollectionViewAdapter {
     }
 
     @inlinable
-    open func controller(at index: Int) -> SectionController? {
+    public func controller(at index: Int) -> SectionController? {
         guard index == 0 else {
             return nil
         }
@@ -20,12 +20,12 @@ extension SingleSectionCollectionViewAdapter {
 
 extension SingleSectionCollectionViewAdapter {
     @inlinable
-    open func dataSource(at indexPath: IndexPath) -> SectionDataSource? {
+    public func dataSource(at indexPath: IndexPath) -> SectionDataSource? {
         controller(at: indexPath)?.dataSource
     }
 
     @inlinable
-    open func dataSource(at index: Int) -> SectionDataSource? {
+    public func dataSource(at index: Int) -> SectionDataSource? {
         controller(at: index)?.dataSource
     }
 }
@@ -33,36 +33,36 @@ extension SingleSectionCollectionViewAdapter {
 @available(iOS 10.0, *)
 extension SingleSectionCollectionViewAdapter {
     @inlinable
-    open func dataSourcePrefetchingDelegate(at indexPath: IndexPath) -> SectionDataSourcePrefetchingDelegate? {
+    public func dataSourcePrefetchingDelegate(at indexPath: IndexPath) -> SectionDataSourcePrefetchingDelegate? {
         controller(at: indexPath)?.dataSourcePrefetchingDelegate
     }
 
     @inlinable
-    open func dataSourcePrefetchingDelegate(at index: Int) -> SectionDataSourcePrefetchingDelegate? {
+    public func dataSourcePrefetchingDelegate(at index: Int) -> SectionDataSourcePrefetchingDelegate? {
         controller(at: index)?.dataSourcePrefetchingDelegate
     }
 }
 
 extension SingleSectionCollectionViewAdapter {
     @inlinable
-    open func delegate(at indexPath: IndexPath) -> SectionDelegate? {
+    public func delegate(at indexPath: IndexPath) -> SectionDelegate? {
         controller(at: indexPath)?.delegate
     }
 
     @inlinable
-    open func delegate(at index: Int) -> SectionDelegate? {
+    public func delegate(at index: Int) -> SectionDelegate? {
         controller(at: index)?.delegate
     }
 }
 
 extension SingleSectionCollectionViewAdapter {
     @inlinable
-    open func flowDelegate(at indexPath: IndexPath) -> SectionFlowDelegate? {
+    public func flowDelegate(at indexPath: IndexPath) -> SectionFlowDelegate? {
         controller(at: indexPath)?.flowDelegate
     }
 
     @inlinable
-    open func flowDelegate(at index: Int) -> SectionFlowDelegate? {
+    public func flowDelegate(at index: Int) -> SectionFlowDelegate? {
         controller(at: index)?.flowDelegate
     }
 }
@@ -70,12 +70,12 @@ extension SingleSectionCollectionViewAdapter {
 @available(iOS 11.0, *)
 extension SingleSectionCollectionViewAdapter {
     @inlinable
-    open func dragDelegate(at indexPath: IndexPath) -> SectionDragDelegate? {
+    public func dragDelegate(at indexPath: IndexPath) -> SectionDragDelegate? {
         controller(at: indexPath)?.dragDelegate
     }
 
     @inlinable
-    open func dragDelegate(at index: Int) -> SectionDragDelegate? {
+    public func dragDelegate(at index: Int) -> SectionDragDelegate? {
         controller(at: index)?.dragDelegate
     }
 }
@@ -83,12 +83,12 @@ extension SingleSectionCollectionViewAdapter {
 @available(iOS 11.0, *)
 extension SingleSectionCollectionViewAdapter {
     @inlinable
-    open func dropDelegate(at indexPath: IndexPath) -> SectionDropDelegate? {
+    public func dropDelegate(at indexPath: IndexPath) -> SectionDropDelegate? {
         controller(at: indexPath)?.dropDelegate
     }
 
     @inlinable
-    open func dropDelegate(at index: Int) -> SectionDropDelegate? {
+    public func dropDelegate(at index: Int) -> SectionDropDelegate? {
         controller(at: index)?.dropDelegate
     }
 }

--- a/SectionKit/Tests/TestUtilities/MockSectionDelegate.swift
+++ b/SectionKit/Tests/TestUtilities/MockSectionDelegate.swift
@@ -278,10 +278,8 @@ internal class MockSectionDelegate: SectionDelegate {
 
     // MARK: - shouldBeginMultipleSelectionInteraction
 
-    @available(iOS 13.0, *)
     internal typealias ShouldBeginMultipleSelectionInteractionBlock = (SectionIndexPath, CollectionViewContext) -> Bool
 
-    @available(iOS 13.0, *)
     internal lazy var _shouldBeginMultipleSelectionInteraction: ShouldBeginMultipleSelectionInteractionBlock = { _, _ in
         XCTFail("not implemented")
         return false
@@ -294,10 +292,8 @@ internal class MockSectionDelegate: SectionDelegate {
 
     // MARK: - didBeginMultipleSelectionInteraction
 
-    @available(iOS 13.0, *)
     internal typealias DidBeginMultipleSelectionInteractionBlock = (SectionIndexPath, CollectionViewContext) -> Void
 
-    @available(iOS 13.0, *)
     internal lazy var _didBeginMultipleSelectionInteraction: DidBeginMultipleSelectionInteractionBlock = { _, _ in
         XCTFail("not implemented")
     }
@@ -312,10 +308,24 @@ internal class MockSectionDelegate: SectionDelegate {
     @available(iOS 13.0, *)
     internal typealias ContextMenuConfigurationForItemBlock = (SectionIndexPath, CGPoint, CollectionViewContext) -> UIContextMenuConfiguration?
 
+    // Since Xcode 14, lazy var don't support the @available attribute anymore, so the following is implemented as a computed property
+    // instead. For reference: https://github.com/apple/swift/pull/41112
+    // Because stored properties don't support it either, the private backing field is implemented as `Any?` and casted to the correct type
+    // whenever it is accessed and is only ever set to an instance of `ContextMenuConfigurationForItemBlock`.
+
+    private var __contextMenuConfigurationForItem: Any?
+
     @available(iOS 13.0, *)
-    internal lazy var _contextMenuConfigurationForItem: ContextMenuConfigurationForItemBlock = { _, _, _ in
-        XCTFail("not implemented")
-        return nil
+    internal var _contextMenuConfigurationForItem: ContextMenuConfigurationForItemBlock {
+        get {
+            (__contextMenuConfigurationForItem as? ContextMenuConfigurationForItemBlock) ?? { _, _, _ in
+                XCTFail("not implemented")
+                return nil
+            }
+        }
+        set {
+            __contextMenuConfigurationForItem = newValue
+        }
     }
 
     @available(iOS 13.0, *)


### PR DESCRIPTION
This PR changes the access modifier of some convenience extensions from `open` to `public` to silence warnings that appear in Xcode 14.
```
Non-'@objc' instance method in extensions cannot be overridden; use 'public' instead
```

It also fixes some issues with `@available` on `lazy var` properties.