### PR TITLE
Fix compile error on Xcode 14.3

### DIFF
--- a/SectionKit/Sources/Utility/UICollectionView+Apply.swift
+++ b/SectionKit/Sources/Utility/UICollectionView+Apply.swift
@@ -54,7 +54,7 @@ extension UICollectionView {
                 if reloads.isNotEmpty {
                     reloadItems(at: reloads.map { IndexPath(item: $0, section: section) })
                 }
-            }, completion: batchOperation.completion)
+            }, completion: { batchOperation.completion?($0) })
         }
     }
 
@@ -108,7 +108,7 @@ extension UICollectionView {
                 if reloads.isNotEmpty {
                     reloadSections(IndexSet(reloads))
                 }
-            }, completion: batchOperation.completion)
+            }, completion: { batchOperation.completion?($0) })
         }
     }
 }


### PR DESCRIPTION
This PR fixes a compile error on Xcode 14.3, for some reason the type checker fails to evaluate the expression (it may have something to do with the `@MainActor` annotation on the `completion` block).