### PR TITLE
Don't pass reference of batchOperation to closure to restore behavior before c7c79c7

### DIFF
--- a/SectionKit/Sources/Utility/UICollectionView+Apply.swift
+++ b/SectionKit/Sources/Utility/UICollectionView+Apply.swift
@@ -54,7 +54,9 @@ extension UICollectionView {
                 if reloads.isNotEmpty {
                     reloadItems(at: reloads.map { IndexPath(item: $0, section: section) })
                 }
-            }, completion: { batchOperation.completion?($0) })
+            }, completion: { [completion = batchOperation.completion] in
+                completion?($0)
+            })
         }
     }
 
@@ -108,7 +110,9 @@ extension UICollectionView {
                 if reloads.isNotEmpty {
                     reloadSections(IndexSet(reloads))
                 }
-            }, completion: { batchOperation.completion?($0) })
+            }, completion: { [completion = batchOperation.completion] in
+                completion?($0)
+            })
         }
     }
 }


### PR DESCRIPTION
c7c79c7808037ec56555e59a373f9339e634457c introduced a regression: 
The completion closure of `UICollectionView.performBatchUpdates(_:completion:)` has a strong reference to `batchOperation`. This causes that the `batchOperation` stays longer in memory as the collection view itself. 

A symptom of this is that `MainCollectionViewContext.apply(update:)` might get called while the `adapter` is deallocated already.

This PR restores behavior to the state before c7c79c7808037ec56555e59a373f9339e634457c by just referencing the `completion` closure instead of `batchOperation`.