### PR TITLE
PE-66817: SectionController support: opt-out from Items changes animation

### DIFF
--- a/SectionKit/Sources/SectionController/Generic/ListSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/ListSectionController.swift
@@ -106,8 +106,25 @@ open class ListSectionController<Model, Item>: BaseSectionController {
         CollectionViewSectionUpdate(
             controller: self,
             data: newData,
+            shouldAnimate: shouldAnimateItems(from: oldData, to: newData),
             setData: { self.collectionViewItems = $0 }
         )
+    }
+
+    /**
+     Controlls where the update from old to new data should be animated.
+     
+     - Parameter oldData: The old data currently displayed in the section.
+     
+     - Parameter newData: The new data that should be displayed in the section.
+     
+     - Returns: Bool. Default true.
+     */
+    open func shouldAnimateItems(
+        from oldData: [Item],
+        to newData: [Item]
+    ) -> Bool {
+        return true
     }
 
     override open func numberOfItems(in context: CollectionViewContext) -> Int { items.count }

--- a/SectionKit/Sources/SectionController/Generic/SingleItemSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/SingleItemSectionController.swift
@@ -123,11 +123,28 @@ open class SingleItemSectionController<Model, Item>: BaseSectionController {
         return CollectionViewSectionUpdate(
             controller: self,
             data: newData,
+            shouldAnimate: shouldAnimateItems(from: oldData, to: newData),
             deletes: deletes,
             inserts: inserts,
             reloads: reloads,
             setData: { self.collectionViewItem = $0 }
         )
+    }
+
+    /**
+     Controlls where the update from old to new data should be animated.
+     
+     - Parameter oldData: The old data currently displayed in the section.
+     
+     - Parameter newData: The new data that should be displayed in the section.
+     
+     - Returns: Bool. Default true.
+     */
+    open func shouldAnimateItems(
+        from oldData:Item?,
+        to newData: Item?
+    ) -> Bool {
+        return true
     }
 
     override open func numberOfItems(in context: CollectionViewContext) -> Int { item != nil ? 1 : 0 }

--- a/SectionKit/Sources/SectionController/Generic/SingleModelSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/SingleModelSectionController.swift
@@ -70,8 +70,25 @@ open class SingleModelSectionController<Model>: BaseSectionController {
         CollectionViewSectionUpdate(
             controller: self,
             data: newData,
+            shouldAnimate: shouldAnimateItems(from: oldData, to: newData),
             setData: { self.collectionViewModel = $0 }
         )
+    }
+    
+    /**
+     Controlls where the update from old to new data should be animated.
+     
+     - Parameter oldData: The old data currently displayed in the section.
+     
+     - Parameter newData: The new data that should be displayed in the section.
+     
+     - Returns: Bool. Default true.
+     */
+    open func shouldAnimateItems(
+        from oldData: Model,
+        to newData: Model
+    ) -> Bool {
+        return true
     }
 
     override open func numberOfItems(in context: CollectionViewContext) -> Int { 1 }

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
@@ -9,6 +9,9 @@ public struct CollectionViewSectionUpdate<SectionData> {
 
     /// The batch operations that should be performed in succession.
     public let batchOperations: [BatchOperation]
+    
+    /// weather the changes should be aniamted
+    public let shouldAnimate: Bool
 
     /// A handler that gets executed inside a batch operation to set the backing data of the current batch of updates.
     public let setData: @MainActor (SectionData) -> Void
@@ -40,11 +43,13 @@ public struct CollectionViewSectionUpdate<SectionData> {
     public init(
         controller: SectionController,
         batchOperations: [BatchOperation],
+        shouldAnimate: Bool = true,
         setData: @escaping @MainActor (SectionData) -> Void,
         shouldReload: @escaping @MainActor (BatchOperation) -> Bool = { _ in false }
     ) {
         self.controller = controller
         self.batchOperations = batchOperations
+        self.shouldAnimate = shouldAnimate
         self.setData = setData
         self.shouldReload = shouldReload
     }
@@ -79,6 +84,7 @@ public struct CollectionViewSectionUpdate<SectionData> {
     public init(
         controller: SectionController,
         data: SectionData,
+        shouldAnimate: Bool = true,
         deletes: Set<Int> = [],
         inserts: Set<Int> = [],
         moves: Set<Move> = [],
@@ -98,6 +104,7 @@ public struct CollectionViewSectionUpdate<SectionData> {
         self.init(
             controller: controller,
             batchOperations: [batchOperation],
+            shouldAnimate: shouldAnimate,
             setData: setData,
             shouldReload: shouldReload
         )
@@ -119,6 +126,7 @@ public struct CollectionViewSectionUpdate<SectionData> {
      */
     public init(
         controller: SectionController,
+        shouldAnimate: Bool = true,
         data: SectionData,
         setData: @escaping @MainActor (SectionData) -> Void,
         completion: (@MainActor (Bool) -> Void)? = nil
@@ -126,6 +134,7 @@ public struct CollectionViewSectionUpdate<SectionData> {
         self.init(
             controller: controller,
             data: data,
+            shouldAnimate: shouldAnimate,
             setData: setData,
             shouldReload: { _ in true },
             completion: completion

--- a/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
+++ b/SectionKit/Sources/SectionController/Update/CollectionViewSectionUpdate.swift
@@ -126,8 +126,8 @@ public struct CollectionViewSectionUpdate<SectionData> {
      */
     public init(
         controller: SectionController,
-        shouldAnimate: Bool = true,
         data: SectionData,
+        shouldAnimate: Bool = true,
         setData: @escaping @MainActor (SectionData) -> Void,
         completion: (@MainActor (Bool) -> Void)? = nil
     ) {

--- a/SectionKit/Sources/Utility/UICollectionView+Apply.swift
+++ b/SectionKit/Sources/Utility/UICollectionView+Apply.swift
@@ -24,6 +24,17 @@ extension UICollectionView {
             return
         }
 
+        guard update.shouldAnimate else {
+            for batchOperation in update.batchOperations {
+                update.setData(batchOperation.data)
+                UIView.performWithoutAnimation {
+                    reloadSections(IndexSet(integer: section))
+                }
+                batchOperation.completion?(false)
+            }
+            return
+        }
+
         for batchOperation in update.batchOperations {
             performBatchUpdates({
                 update.setData(batchOperation.data)


### PR DESCRIPTION
Provide support to opt-out from animations for Section updates.

The implementation
1.  Leaves the animations opted in by default.
2. When needed the section controller can override the method and return false/true