### PR TITLE
DEVXP-3006: Add missing catalog-info.yaml

### DIFF
--- a/.traderepublic/catalog-info.yaml
+++ b/.traderepublic/catalog-info.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sectionkit
+spec:
+  type: service
+  lifecycle: production
+  owner: element-managed-products


### PR DESCRIPTION
## Summary

This PR adds a minimal `catalog-info.yaml` file to register this repository in Backstage.

## Changes

- Added `.traderepublic/catalog-info.yaml` with 6 required fields only
- Component type: `service`, Lifecycle: `production`, Owner: `element-managed-products`

## Action Required: Verify Ownership

Owner is set to `element-managed-products` based on repository topics. Please verify this is correct.

## Action Required: Add Annotations

Per [RFC](https://traderepublic.atlassian.net/wiki/spaces/Platform/pages/4558422180), add required annotations like Slack channels.

## Next Steps

1. Review the generated `catalog-info.yaml`
2. Verify/correct the `owner` field
3. Add any required annotations (slack channels, etc.)
4. Adjust `type` if needed (API, Library, etc.)
5. Merge to complete catalog registration

🤖 Automated by DEVXP-3006
