### PR TITLE
Respect `shouldAnimateItems` in diffing section controllers

### DIFF
--- a/DiffingSectionKit/Sources/DiffingListSectionController.swift
+++ b/DiffingSectionKit/Sources/DiffingListSectionController.swift
@@ -18,6 +18,7 @@ open class DiffingListSectionController<Model, Item: Differentiable>: ListSectio
         return CollectionViewSectionUpdate(
             controller: self,
             batchOperations: changeSet.map(\.sectionBatchOperation),
+            shouldAnimate: shouldAnimateItems(from: oldData, to: newData),
             setData: { self.collectionViewItems = $0 },
             shouldReload: { $0.count > 100 }
         )

--- a/DiffingSectionKit/Sources/ManualDiffingListSectionController.swift
+++ b/DiffingSectionKit/Sources/ManualDiffingListSectionController.swift
@@ -49,6 +49,7 @@ open class ManualDiffingListSectionController<
         return CollectionViewSectionUpdate(
             controller: self,
             batchOperations: changeSet.mapData(\.value).map(\.sectionBatchOperation),
+            shouldAnimate: shouldAnimateItems(from: oldData, to: newData),
             setData: { self.collectionViewItems = $0 },
             shouldReload: { $0.count > 100 }
         )

--- a/SectionKit/Sources/SectionController/Generic/FoundationDiffingListSectionController.swift
+++ b/SectionKit/Sources/SectionController/Generic/FoundationDiffingListSectionController.swift
@@ -23,6 +23,7 @@ open class FoundationDiffingListSectionController<
         return CollectionViewSectionUpdate(
             controller: self,
             data: newData,
+            shouldAnimate: shouldAnimateItems(from: oldData, to: newData),
             deletes: changes.deletes,
             inserts: changes.inserts,
             moves: changes.moves,


### PR DESCRIPTION
Ticket: PTECH-34068

## Summary

Fixes section controller base classes to respect `shouldAnimateItems(from:to:)` overrides.

`DiffingListSectionController`, `ManualDiffingListSectionController`, and `FoundationDiffingListSectionController` all override `calculateUpdate(from:to:)` but never pass `shouldAnimateItems(from:to:)` to the `CollectionViewSectionUpdate` initializer, causing it to always default to `true`.

This means subclasses that override `shouldAnimateItems` to return `false` have no effect — updates are always animated

Fix by threading the `shouldAnimateItems` result through to the `shouldAnimate` parameter in all three controllers, matching the behavior of the base `ListSectionController.calculateUpdate`.
